### PR TITLE
add conda_build_config.yaml project-wide config

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,0 +1,30 @@
+c_compiler:         # [win]
+  - vs2008          # [win]
+  - vs2015          # [win]
+cxx_compiler:       # [win]
+  - vs2008          # [win]
+  - vs2015          # [win]
+hdf5:
+  - 1.8
+  - 1.10
+macos_min_version:
+  - 10.9
+numpy:
+  - 1.7             # [py<34]
+  - 1.9             # [py35]
+  - 1.11            # [py>35]
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+target_platform:
+  - win-64          # [win]
+  - win-32          # [win]
+vc:
+  - 9               # [win]
+  - 14              # [win]
+zip_keys:
+  -                 # [win]
+    - vc            # [win]
+    - c_compiler    # [win]
+    - cxx_compiler  # [win]


### PR DESCRIPTION
In several PR's, I have been saying that those PR's depend on a conda_build_config.yaml that I did not include.  This is that conda_build_config.yaml file.  This file establishes the overall version space for all builds.

The key implementation detail here is that rendering is done with the current working directory being the root of this repo.  Thus, this conda_build_config.yaml takes effect for all recipes here.  It can be overridden (reduced, expanded, or changed) by conda_build_config.yaml files that live alongside meta.yaml files in any of the recipes.

CC @mingwandroid @nehaljwani @jjhelmus