### PR TITLE
add win and mac 'pass-through' compiler recipes

### DIFF
--- a/clang/activate.sh
+++ b/clang/activate.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# check if clang exists. stderr is thrown away by dev/null
+if hash clang 2>/dev/null && xcodebuild -showsdks | grep -q "\-sdk macosx@macos_min_version@"
+then
+    # for Mac OSX
+    export CC=clang
+    export CXX=clang++
+    export MACOSX_DEPLOYMENT_TARGET="@macos_min_version@"
+    export CMAKE_OSX_DEPLOYMENT_TARGET="@macos_min_version@"
+    export CFLAGS="${CFLAGS} -mmacosx-version-min=@macos_min_version@"
+    export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=@macos_min_version@"
+    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
+    export LDFLAGS="${LDFLAGS} -headerpad_max_install_names"
+    export LDFLAGS="${LDFLAGS} -mmacosx-version-min=@macos_min_version@"
+    export LDFLAGS="${LDFLAGS} -lc++"
+    export LINKFLAGS="${LDFLAGS}"
+else
+    echo "This system is unsupported by this recipe."
+    exit 1
+fi

--- a/clang/install-clang.sh
+++ b/clang/install-clang.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p ${PREFIX}/etc/conda/activate.d/
+
+cp ${RECIPE_DIR}/activate.sh ${PREFIX}/etc/conda/activate.d/conda_"${PKG_NAME}".sh
+# hard-code the sdk version we build for
+sed -i '' "s/@macos_min_version@/${macos_min_version}/" ${PREFIX}/etc/conda/activate.d/conda_"${PKG_NAME}".sh

--- a/clang/install-clangxx.sh
+++ b/clang/install-clangxx.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p ${PREFIX}/etc/conda/activate.d/
+
+cp ${RECIPE_DIR}/activate.sh ${PREFIX}/etc/conda/activate.d/conda_"${PKG_NAME}".sh
+# hard-code the sdk version we build for
+sed -i '' "s/@macos_min_version@/${macos_min_version}/" ${PREFIX}/etc/conda/activate.d/conda_"${PKG_NAME}".sh

--- a/clang/meta.yaml
+++ b/clang/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: clang_{{ target_platform }}
+  version: {{ macos_min_version }}
+
+build:
+  skip: True  [not osx]
+
+outputs:
+  - name: clang_{{ target_platform }}
+    script: install-clang.sh
+  - name: clangxx_{{ target_platform }}
+    script: install-clangxx.sh

--- a/vs2008/activate.bat
+++ b/vs2008/activate.bat
@@ -1,0 +1,38 @@
+:: Set env vars that tell distutils to use the compiler that we put on path
+SET DISTUTILS_USE_SDK=1
+SET MSSdk=1
+
+:: http://stackoverflow.com/a/26874379/1170370
+SET platform=
+IF /I [%PROCESSOR_ARCHITECTURE%]==[amd64] set platform=true
+IF /I [%PROCESSOR_ARCHITEW6432%]==[amd64] set platform=true
+
+if defined platform (
+set "VSREGKEY=HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\9.0"
+)  ELSE (
+set "VSREGKEY=HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\9.0"
+)
+for /f "skip=2 tokens=2,*" %%A in ('reg query "%VSREGKEY%" /v InstallDir') do SET "VSINSTALLDIR=%%B"
+
+if not "%VSINSTALLDIR%" == "" (
+   :: Look in VS90COMNTOOLS
+   set "VSINSTALLDIR=%VS90COMNTOOLS%"
+)
+
+if "%VSINSTALLDIR%" == "" (
+   ECHO "Did not find VS in registry or in VS90COMNTOOLS env var - exiting"
+   exit 1
+)
+
+echo "Found VS2008 at"
+echo "%VSINSTALLDIR%"
+
+SET "VS_VERSION=9.0"
+SET "VS_MAJOR=9"
+SET "VS_YEAR=2008"
+
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+set "MSYS2_ENV_CONV_EXCL=CL"
+
+:: other things added by install_activate.bat at package build time
+

--- a/vs2008/install_activate.bat
+++ b/vs2008/install_activate.bat
@@ -1,0 +1,22 @@
+set YEAR=2008
+set VER=9
+
+mkdir "%PREFIX%\etc\conda\activate.d"
+COPY "%RECIPE_DIR%\activate.bat" "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+
+
+if "%ARCH%" == "64" (
+    :: 64-bit
+    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR% Win64" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+) else (
+    :: 32-bit
+    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+)
+
+IF "%target_platform%" == "win-64" (
+  set "target_platform=amd64"
+  ) else (
+  set "target_platform=x86"
+  )
+
+echo CALL "%%VSINSTALLDIR%%\..\..\VC\vcvarsall.bat" %target_platform% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"

--- a/vs2008/meta.yaml
+++ b/vs2008/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: vs2008
+  version: "9.00.30729.1"
+
+build:
+  skip: True  [not win]
+
+outputs:
+  - name: vs2008_{{ target_platform }}
+    script: install_activate.bat
+    run_exports:
+      - vc 9
+about:
+  summary: Activation and version verification of MSVC 9 (VS 2008) compiler
+  license: BSD 3-clause

--- a/vs2010/activate.bat
+++ b/vs2010/activate.bat
@@ -1,0 +1,50 @@
+:: Set env vars that tell distutils to use the compiler that we put on path
+SET DISTUTILS_USE_SDK=1
+SET MSSdk=1
+
+:: http://stackoverflow.com/a/26874379/1170370
+SET platform=
+IF /I [%PROCESSOR_ARCHITECTURE%]==[amd64] set platform=true
+IF /I [%PROCESSOR_ARCHITEW6432%]==[amd64] set platform=true
+
+:: the Environment variable VisualStudioVersion is set by devenv.exe
+:: if this batch is a child of devenv.exe external tools, we know which version to look at
+set VisualStudioVersion=10.0
+
+if defined platform (
+set VSREGKEY=HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\%VisualStudioVersion%
+)  ELSE (
+set VSREGKEY=HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\%VisualStudioVersion%
+)
+for /f "skip=2 tokens=2,*" %%A in ('reg query "%VSREGKEY%" /v InstallDir') do SET VSINSTALLDIR=%%B
+
+if not "%VSINSTALLDIR%" == "" (
+   set VSINSTALLDIR=%VS100COMNTOOLS%
+)
+
+if "%VSINSTALLDIR%" == "" (
+   ECHO "Did not find VS in registry or in VS90COMNTOOLS env var - exiting"
+   exit 1
+)
+
+echo "Found VS2010 at"
+echo "%VSINSTALLDIR%"
+
+
+CALL
+
+SET "VS_VERSION=10.0"
+SET "VS_MAJOR=10"
+SET "VS_YEAR=2010"
+
+if "%ARCH%" == "64" (
+    :: 64-bit
+    SET "CMAKE_GENERATOR=Visual Studio %VS_MAJOR% %VS_YEAR% Win64"
+) else (
+    :: 32-bit
+    SET "CMAKE_GENERATOR=Visual Studio %VS_MAJOR% %VS_YEAR%"
+)
+
+
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+set "MSYS2_ENV_CONV_EXCL=CL"

--- a/vs2010/install_activate.bat
+++ b/vs2010/install_activate.bat
@@ -1,0 +1,22 @@
+set YEAR=2010
+set VER=10
+
+mkdir "%PREFIX%\etc\conda\activate.d"
+COPY "%RECIPE_DIR%\activate.bat" "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+
+
+if "%ARCH%" == "64" (
+    :: 64-bit
+    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR% Win64" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+) else (
+    :: 32-bit
+    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+)
+
+IF "%target_platform%" == "win-64" (
+  set "target_platform=amd64"
+  ) else (
+  set "target_platform=x86"
+  )
+
+echo CALL "%%VSINSTALLDIR%%\..\..\VC\vcvarsall.bat" %target_platform% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"

--- a/vs2010/meta.yaml
+++ b/vs2010/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: vs2010
+  version: "10.00.40219.1"
+
+build:
+  skip: True  [not win]
+
+outputs:
+  - name: vs2010_{{ target_platform }}
+    script: install_activate.bat
+    run_exports:
+      - vc 10
+
+about:
+  summary: Activation and version verification of MSVC 10 (VS 2010) compiler
+  license: BSD 3-clause

--- a/vs2015/activate.bat
+++ b/vs2015/activate.bat
@@ -1,0 +1,39 @@
+:: Set env vars that tell distutils to use the compiler that we put on path
+SET DISTUTILS_USE_SDK=1
+SET MSSdk=1
+
+:: http://stackoverflow.com/a/26874379/1170370
+SET platform=
+IF /I [%PROCESSOR_ARCHITECTURE%]==[amd64] set "platform=true"
+IF /I [%PROCESSOR_ARCHITEW6432%]==[amd64] set "platform=true"
+
+if defined platform (
+set "VSREGKEY=HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\14.0"
+)  ELSE (
+set "VSREGKEY=HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\14.0"
+)
+for /f "skip=2 tokens=2,*" %%A in ('reg query "%VSREGKEY%" /v InstallDir') do SET "VSINSTALLDIR=%%B"
+
+if not "%VSINSTALLDIR%" == "" (
+   set "VSINSTALLDIR=%VS140COMNTOOLS%"
+)
+
+if "%VSINSTALLDIR%" == "" (
+   ECHO "Did not find VS in registry or in VS140COMNTOOLS env var - exiting"
+   exit 1
+)
+
+echo "Found VS2014 at %VSINSTALLDIR%"
+
+SET "VS_VERSION=14.0"
+SET "VS_MAJOR=14"
+SET "VS_YEAR=2015"
+
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+set "MSYS2_ENV_CONV_EXCL=CL"
+
+:: For Python 3.5+, ensure that we link with the dynamic runtime.  See
+:: http://stevedower.id.au/blog/building-for-python-3-5-part-two/ for more info
+set "PY_VCRUNTIME_REDIST=%PREFIX%\\bin\\vcruntime140.dll"
+
+:: other things added by install_activate.bat at package build time

--- a/vs2015/install_activate.bat
+++ b/vs2015/install_activate.bat
@@ -1,0 +1,22 @@
+set YEAR=2015
+set VER=14
+
+mkdir "%PREFIX%\etc\conda\activate.d"
+COPY "%RECIPE_DIR%\activate.bat" "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+
+
+if "%ARCH%" == "64" (
+    :: 64-bit
+    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR% Win64" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+) else (
+    :: 32-bit
+    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+)
+
+IF "%target_platform%" == "win-64" (
+  set "target_platform=amd64"
+  ) else (
+  set "target_platform=x86"
+  )
+
+echo CALL "%%VSINSTALLDIR%%\..\..\VC\vcvarsall.bat" %target_platform% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"

--- a/vs2015/meta.yaml
+++ b/vs2015/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: vs2015
+  version: "14.0.25123"
+
+build:
+  skip: True  [not win]
+
+outputs:
+  - name: vs2015_{{ target_platform }}
+    script: install_activate.bat
+    run_exports:
+      - vc 14
+about:
+  summary: Activation and version verification of MSVC 14 (VS 2015) compiler
+  license: BSD 3-clause


### PR DESCRIPTION
when people use conda-build 3's {{compiler('language') }} syntax, conda-build goes looking for compiler packages.  On Windows, these will not be actual compiler packages, but rather packages that run the correct activation scripts to set up compilers that are already installed on the system.  On mac, we are working on proper compiler packages, but until then, we have a package that does a version check to make sure that the SDK in use is producing software with the expected backwards compatibility.

NOTE: I have not yet fully ported the fallback behavior for VS 2008 or VS 2010 to compilers other than the ones that come with VS.  For example, the VC compiler for Python 2.7 that appveyor uses for 64-bit compiling.  If anyone would like to help, I'd greatly appreciate it.

This PR depends on #1 for complete functionality.

CC @patricksnape