### PR TITLE
add track_features for vs20?? packages, to activate features

### DIFF
--- a/vs2008/meta.yaml
+++ b/vs2008/meta.yaml
@@ -4,6 +4,8 @@ package:
 
 build:
   skip: True  [not win]
+  track_features:
+    - vc9
 
 outputs:
   - name: vs2008_{{ target_platform }}

--- a/vs2010/meta.yaml
+++ b/vs2010/meta.yaml
@@ -4,6 +4,8 @@ package:
 
 build:
   skip: True  [not win]
+  track_features:
+    - vc10
 
 outputs:
   - name: vs2010_{{ target_platform }}

--- a/vs2015/meta.yaml
+++ b/vs2015/meta.yaml
@@ -4,6 +4,8 @@ package:
 
 build:
   skip: True  [not win]
+  track_features:
+    - vc14
 
 outputs:
   - name: vs2015_{{ target_platform }}


### PR DESCRIPTION
With this change, the vc package should almost never need to explicitly be used.  Installing the compiler will activate the feature, and run_exports will add it to run deps as necessary.