### PR TITLE
add cross_compiler_target_platform for proper win looping

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -53,10 +53,21 @@ numpy:
   - 1.11                       # [py>35]
 perl:
   - 5.26
+proj4:
+  - 4
 python:
   - 2.7
   - 3.5
   - 3.6
+sqlite:
+  - 3
+# This differs from target_platform in that it determines what subdir the compiler
+#    will target, not what subdir the compiler package will be itself.
+#    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32
+#    code on win-64 miniconda.
+cross_compiler_target_platform:
+  - win-32                     # [win]
+  - win-64                     # [win]
 target_platform:
   - win-64                     # [win]
   - win-32                     # [win]
@@ -66,11 +77,16 @@ vc:
   - 14                         # [win]
 zlib:
   - 1.2
+xz:
+  - 5
 zip_keys:
-  -                            # [win or osx]
-    - vc                       # [win]
-    - c_compiler               # [win]
-    - cxx_compiler             # [win]
-    - python                   # [win]
-    - macos_min_version        # [osx]
-    - macos_machine            # [osx]
+  -                             # [win]
+    - vc                        # [win]
+    - c_compiler                # [win]
+    - cxx_compiler              # [win]
+    - python                    # [win]
+  -                             # [osx]
+    - macos_min_version         # [osx]
+    - macos_machine             # [osx]
+    - MACOSX_DEPLOYMENT_TARGET  # [osx]
+    - CONDA_BUILD_SYSROOT       # [osx]

--- a/vs2008/install_activate.bat
+++ b/vs2008/install_activate.bat
@@ -4,19 +4,12 @@ set VER=9
 mkdir "%PREFIX%\etc\conda\activate.d"
 COPY "%RECIPE_DIR%\activate.bat" "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 
-
-if "%ARCH%" == "64" (
-    :: 64-bit
-    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR% Win64" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-) else (
-    :: 32-bit
-    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-)
-
-IF "%target_platform%" == "win-64" (
+IF "%cross_compiler_target_platform%" == "win-64" (
   set "target_platform=amd64"
+  echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR% Win64" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   ) else (
   set "target_platform=x86"
+    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   )
 
 echo CALL "%%VSINSTALLDIR%%\..\..\VC\vcvarsall.bat" %target_platform% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"

--- a/vs2008/meta.yaml
+++ b/vs2008/meta.yaml
@@ -8,7 +8,7 @@ build:
     - vc9
 
 outputs:
-  - name: vs2008_{{ target_platform }}
+  - name: vs2008_{{ cross_compiler_target_platform }}
     script: install_activate.bat
     run_exports:
       - vc 9

--- a/vs2010/install_activate.bat
+++ b/vs2010/install_activate.bat
@@ -4,19 +4,12 @@ set VER=10
 mkdir "%PREFIX%\etc\conda\activate.d"
 COPY "%RECIPE_DIR%\activate.bat" "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 
-
-if "%ARCH%" == "64" (
-    :: 64-bit
-    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR% Win64" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-) else (
-    :: 32-bit
-    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-)
-
-IF "%target_platform%" == "win-64" (
+IF "%cross_compiler_target_platform%" == "win-64" (
   set "target_platform=amd64"
+  echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR% Win64" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   ) else (
   set "target_platform=x86"
+    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   )
 
 echo CALL "%%VSINSTALLDIR%%\..\..\VC\vcvarsall.bat" %target_platform% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"

--- a/vs2010/meta.yaml
+++ b/vs2010/meta.yaml
@@ -8,7 +8,7 @@ build:
     - vc10
 
 outputs:
-  - name: vs2010_{{ target_platform }}
+  - name: vs2010_{{ cross_compiler_target_platform }}
     script: install_activate.bat
     run_exports:
       - vc 10

--- a/vs2015/install_activate.bat
+++ b/vs2015/install_activate.bat
@@ -4,19 +4,12 @@ set VER=14
 mkdir "%PREFIX%\etc\conda\activate.d"
 COPY "%RECIPE_DIR%\activate.bat" "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 
-
-if "%ARCH%" == "64" (
-    :: 64-bit
-    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR% Win64" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-) else (
-    :: 32-bit
-    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-)
-
-IF "%target_platform%" == "win-64" (
+IF "%cross_compiler_target_platform%" == "win-64" (
   set "target_platform=amd64"
+  echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR% Win64" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   ) else (
   set "target_platform=x86"
+    echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   )
 
 echo CALL "%%VSINSTALLDIR%%\..\..\VC\vcvarsall.bat" %target_platform% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"

--- a/vs2015/meta.yaml
+++ b/vs2015/meta.yaml
@@ -8,7 +8,7 @@ build:
     - vc14
 
 outputs:
-  - name: vs2015_{{ target_platform }}
+  - name: vs2015_{{ cross_compiler_target_platform }}
     script: install_activate.bat
     run_exports:
       - vc 14


### PR DESCRIPTION
Without this, the vs20?? compiler packages end up only being built for target_platform, so vs2008_win-32 is only available for installation on win-32.  That's not right.  We want to be able to install vs2008_win-32 on win-64 so that we target win-32, but using a win-64 miniconda install.