### PR TITLE
Add theano-feedstock

### DIFF
--- a/theano-feedstock/0001-Add-support-for-custom-compiler.patch
+++ b/theano-feedstock/0001-Add-support-for-custom-compiler.patch
@@ -1,0 +1,44 @@
+From 71b0fe302841fff91d366aabb3f3abe81b381e12 Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Sun, 3 Dec 2017 10:38:03 -0600
+Subject: [PATCH] Add support for custom compiler
+
+---
+ theano/configdefaults.py | 4 ++--
+ theano/gof/cmodule.py    | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/theano/configdefaults.py b/theano/configdefaults.py
+index 882114e69..90172e820 100644
+--- a/theano/configdefaults.py
++++ b/theano/configdefaults.py
+@@ -441,11 +441,11 @@ AddConfigVar(
+             'FAST_COMPILE', 'DEBUG_MODE'),
+     in_c_key=False)
+ 
+-param = "g++"
++param = os.environ.get("CXX", "g++")
+ 
+ # Test whether or not g++ is present: disable C code if it is not.
+ try:
+-    rc = call_subprocess_Popen(['g++', '-v'])
++    rc = call_subprocess_Popen([param, '-v'])
+ except OSError:
+     rc = 1
+ 
+diff --git a/theano/gof/cmodule.py b/theano/gof/cmodule.py
+index aef42b3d5..73c670d56 100644
+--- a/theano/gof/cmodule.py
++++ b/theano/gof/cmodule.py
+@@ -1901,7 +1901,7 @@ class GCC_compiler(Compiler):
+                     GCC_compiler.march_flags = []
+                     break
+ 
+-        if ('g++' not in theano.config.cxx and
++        if (os.environ.get('CXX', 'g++') not in theano.config.cxx and
+                 'clang++' not in theano.config.cxx and
+                 'clang-omp++' not in theano.config.cxx and
+                 'icpc' not in theano.config.cxx):
+-- 
+2.14.1
+

--- a/theano-feedstock/meta.yaml
+++ b/theano-feedstock/meta.yaml
@@ -1,0 +1,76 @@
+package:
+  name: theano
+  version: 0.9.0
+
+source:
+  git_url: https://github.com/Theano/Theano.git
+  git_tag: rel-0.9.0
+  patches:
+    - 0001-Add-support-for-custom-compiler.patch
+
+build:
+  number: 3
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  host:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - mkl-service     # [not ppc64le]
+    - libpython >=2.0         # [win]
+    - m2w64-toolchain         # [win]
+    - six >=1.9.0
+    - numpy >=1.9.1
+    - scipy >=0.14.0
+    - pygpu >=0.6.5,<0.7
+    - setuptools
+    - {{ compiler('cxx') }}  # [unix]
+
+test:
+  requires:
+    - nose >=1.3.0
+    - nose-parameterized >=0.5.0
+
+  imports:
+    - theano
+    - theano.compile
+    - theano.compile.sandbox
+    - theano.compile.tests
+    - theano.gof
+    - theano.gof.tests
+    - theano.misc
+    - theano.sandbox
+    - theano.sandbox.cuda
+    - theano.sandbox.cuda.tests
+    - theano.scalar
+    - theano.scalar.tests
+    - theano.sparse
+    - theano.sparse.tests
+    - theano.tensor
+    - theano.tensor.nnet
+    - theano.tensor.nnet.tests
+    - theano.tensor.signal
+    - theano.tensor.signal.tests
+    - theano.tensor.tests
+    - theano.tests
+
+  commands:
+    - theano-cache help
+    - theano-nose --help
+
+about:
+  home: http://deeplearning.net/software/theano/
+  license: BSD 3-Clause
+  license_family: BSD
+  summary: Optimizing compiler for evaluating mathematical expressions on CPUs and GPUs.
+  description: |
+    Theano is a Python library that allows you to define, optimize, and
+    evaluate mathematical expressions involving multi-dimensional arrays
+    efficiently, featuring tight integration with NumPy, transparent use
+    of a GPU, efficient symbolic differentiation, speed and stability
+    optimizations and dynamic C code generation.
+  dev_url: https://github.com/Theano/Theano
+  doc_url: http://deeplearning.net/software/theano/


### PR DESCRIPTION
I'm adding the 0.9.0 version and not the 1.0.0 version because we want to fix the dependency on pygpu(<7.0) and we also want to make theano aware of the new cross compilers.

After this is merged, I'll wait for a while, then update libgpuarray and pygpu and then update theano to 1.0.0

