### PR TITLE
ruamel-feedstock namespace package

### DIFF
--- a/ruamel-feedstock/recipe/LICENSE
+++ b/ruamel-feedstock/recipe/LICENSE
@@ -1,0 +1,7 @@
+Copyright Anaconda, Inc. 2017
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/ruamel-feedstock/recipe/meta.yaml
+++ b/ruamel-feedstock/recipe/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: ruamel
+  version: 0.1.0
+
+source:
+  path: .
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - ruamel
+
+about:
+  home: https://bitbucket.org/ruamel
+  license: MIT
+  license_file: LICENSE
+  summary: Namespace conda package for the ruamel python namespace.
+  dev_url: https://github.com/AnacondaRecipes/ruamel-feedstock

--- a/ruamel-feedstock/recipe/setup.py
+++ b/ruamel-feedstock/recipe/setup.py
@@ -1,0 +1,11 @@
+from distutils.core import setup
+
+setup(
+    name="ruamel",
+    version="0.1.0",
+    author="Anaconda, Inc.",
+    license="MIT",
+    description="Namespace package for ruamel namespace.",
+    packages=("ruamel",),
+    zip_safe=False,
+)


### PR DESCRIPTION
This PR is for the `ruamel` namespace package, which really only contains `$SP_DIR/ruamel/__init__.py` and accompanying pyc file.  We need this package so that we can do `ruamel.ordereddict` and `ruamel.yaml` correctly.