### PR TITLE
Add mkl-dnn-feedstock

### DIFF
--- a/mkl-dnn-feedstock/recipe/0001-src-jit-do-not-ignore-the-result-of-fwrite.patch
+++ b/mkl-dnn-feedstock/recipe/0001-src-jit-do-not-ignore-the-result-of-fwrite.patch
@@ -1,0 +1,39 @@
+From 98913b4c1e12f2452988831a4b13bdbee1cf526c Mon Sep 17 00:00:00 2001
+From: "Fomenko, Evarist M" <evarist.m.fomenko@intel.com>
+Date: Tue, 15 May 2018 16:32:59 +0000
+Subject: [PATCH] src: jit: do not ignore the result of fwrite...
+
+... at least from compiler point of view.
+On some systems with old glibc (<= 2.15) the fwrite function has
+the warn_unused_result attribute. That makes MKL-DNN build fail.
+Starting with glibc 2.16 the attribute was removed [1].
+
+Alas, no regression test can be implemented here.
+
+This closes #236.
+
+[1]
+The bug: https://sourceware.org/bugzilla/show_bug.cgi?id=11959
+Release notes to 2.16:
+https://sourceware.org/ml/libc-alpha/2012-06/msg00807.html
+---
+ src/cpu/jit_generator.hpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/cpu/jit_generator.hpp b/src/cpu/jit_generator.hpp
+index 49204e0..4c730e1 100644
+--- a/src/cpu/jit_generator.hpp
++++ b/src/cpu/jit_generator.hpp
+@@ -719,7 +719,8 @@ public:
+             FILE *fp = mkldnn_fopen(fname, "w+");
+             // Failure to dump code is not fatal
+             if (fp) {
+-                fwrite(code, getSize(), 1, fp);
++                size_t unused = fwrite(code, getSize(), 1, fp);
++                UNUSED(unused);
+                 fclose(fp);
+             }
+         }
+-- 
+2.17.0
+

--- a/mkl-dnn-feedstock/recipe/0002-Add-MKL_ROOT-bin-directory-for-DLLs.patch
+++ b/mkl-dnn-feedstock/recipe/0002-Add-MKL_ROOT-bin-directory-for-DLLs.patch
@@ -1,0 +1,35 @@
+From ed3c2e19c1b4ae60b423f7e0db0245db1f1bf650 Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Fri, 29 Jun 2018 15:50:40 -0500
+Subject: [PATCH 2/2] Add ${MKL_ROOT}/bin directory for DLLs
+
+---
+ cmake/MKL.cmake | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/cmake/MKL.cmake b/cmake/MKL.cmake
+index 57acaab..b4ef058 100644
+--- a/cmake/MKL.cmake
++++ b/cmake/MKL.cmake
+@@ -73,6 +73,7 @@ function(detect_mkl LIBNAME)
+             HINTS
+                 ${MKLREDIST}/mkl
+                 ${MKLREDIST}/intel64/mkl
++                ${__mklinc_root}/bin
+                 ${__mklinc_root}/lib)
+         if(NOT MKLDLL)
+             return()
+@@ -102,7 +103,9 @@ function(detect_mkl LIBNAME)
+         if(WIN32)
+             find_file(MKLIOMP5DLL
+                 NAMES "libiomp5.dll" "libiomp5md.dll"
+-                HINTS ${MKLREDIST}/../compiler ${__mklinc_root}/lib)
++                HINTS ${MKLREDIST}/../compiler
++                ${__mklinc_root}/bin
++                ${__mklinc_root}/lib)
+             if(NOT MKLIOMP5DLL)
+                 return()
+             endif()
+-- 
+2.17.0
+

--- a/mkl-dnn-feedstock/recipe/bld.bat
+++ b/mkl-dnn-feedstock/recipe/bld.bat
@@ -1,0 +1,16 @@
+mkdir build && cd build
+
+cmake -G"%CMAKE_GENERATOR%" ^
+  -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+  -DCMAKE_BUILD_TYPE=Release ^
+  -DMKLROOT="%LIBRARY_PREFIX%" ^
+  %SRC_DIR%
+if errorlevel 1 exit 1
+
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+ctest
+
+cmake --build . --target install
+if errorlevel 1 exit 1

--- a/mkl-dnn-feedstock/recipe/build.sh
+++ b/mkl-dnn-feedstock/recipe/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -x
+
+cmake -G"$CMAKE_GENERATOR" \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DMKLROOT="${PREFIX}" \
+  ${SRC_DIR}
+
+cmake --build . --config Release
+
+ctest
+
+cmake --build . --target install

--- a/mkl-dnn-feedstock/recipe/intel_find_libs.patch
+++ b/mkl-dnn-feedstock/recipe/intel_find_libs.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 048dcfba..560df027 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -53,6 +53,8 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "")
+     set(CMAKE_BUILD_TYPE "Release")
+ endif()
+ 
++link_directories(${PREFIX}/lib)
++
+ include("cmake/platform.cmake")
+ include("cmake/OpenMP.cmake")
+ include("cmake/SDL.cmake")

--- a/mkl-dnn-feedstock/recipe/meta.yaml
+++ b/mkl-dnn-feedstock/recipe/meta.yaml
@@ -16,7 +16,8 @@ build:
   number: 0
   # linux32: https://github.com/01org/mkl-dnn/issues/171
   # vc<14: pre-c99 era :'(
-  skip: True  # [linux32 or (win and vc<14)]
+  skip: True  # [not x86_64]
+  skip: True  # [win and vc<14]
 
 requirements:
   build:

--- a/mkl-dnn-feedstock/recipe/meta.yaml
+++ b/mkl-dnn-feedstock/recipe/meta.yaml
@@ -1,0 +1,45 @@
+{% set version="0.14" %}
+
+package:
+  name: mkl-dnn
+  version: {{ version }}
+
+source:
+  - url: https://github.com/intel/mkl-dnn/archive/v{{ version }}.tar.gz
+    sha256: efebc53882856afec86457a2da644693f5d59c68772d41d640d6b60a8efc4eb0
+    patches:
+      - intel_find_libs.patch
+      - 0001-src-jit-do-not-ignore-the-result-of-fwrite.patch
+      - 0002-Add-MKL_ROOT-bin-directory-for-DLLs.patch
+
+build:
+  number: 0
+  # linux32: https://github.com/01org/mkl-dnn/issues/171
+  # vc<14: pre-c99 era :'(
+  skip: True  # [linux32 or (win and vc<14)]
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake >=2.8.0
+  host:
+    - intel-openmp
+    - mklml
+  run:
+    - {{ pin_compatible('intel-openmp') }}
+
+about:
+  home: https://01.org/mkl-dnn
+  license: Apache 2.0
+  license_file: LICENSE
+  license_family: Apache
+  summary: Intel(R) Math Kernel Library for Deep Neural Networks (Intel(R) MKL-DNN)
+  description: |
+    Intel(R) Math Kernel Library for Deep Neural Networks (Intel(R) MKL-DNN) is
+    an open source performance library for Deep Learning (DL) applications
+    intended for acceleration of DL frameworks on Intel(R) architecture.
+    Intel(R) MKL-DNN includes highly vectorized and threaded building blocks
+    for implementation of convolutional neural networks (CNN) with C and C++
+    interfaces.
+  dev_url: https://github.com/01org/mkl-dnn
+  doc_url: http://01org.github.io/mkl-dnn

--- a/mklml-feedstock/recipe/install-libmklml.bat
+++ b/mklml-feedstock/recipe/install-libmklml.bat
@@ -1,0 +1,6 @@
+mkdir %LIBRARY_PREFIX%
+mkdir %LIBRARY_LIB%
+mkdir %LIBRARY_BIN%
+
+copy mklml\lib\mklml.dll %LIBRARY_BIN%
+copy mklml\lib\mklml.lib %LIBRARY_LIB%

--- a/mklml-feedstock/recipe/install-libmklml.sh
+++ b/mklml-feedstock/recipe/install-libmklml.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ ${HOST} =~ .*darwin.* ]]; then
+  cp mklml/lib/libmklml${SHLIB_EXT} $PREFIX/lib
+else
+  cp mklml/lib/libmklml_intel${SHLIB_EXT} $PREFIX/lib
+fi

--- a/mklml-feedstock/recipe/install-libmklml.sh
+++ b/mklml-feedstock/recipe/install-libmklml.sh
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-if [[ ${HOST} =~ .*darwin.* ]]; then
-  cp mklml/lib/libmklml${SHLIB_EXT} $PREFIX/lib
-else
-  cp mklml/lib/libmklml_intel${SHLIB_EXT} $PREFIX/lib
-fi
+cp mklml/lib/libmklml*${SHLIB_EXT} $PREFIX/lib

--- a/mklml-feedstock/recipe/meta.yaml
+++ b/mklml-feedstock/recipe/meta.yaml
@@ -15,6 +15,10 @@ source:
   sha256: a584a5bf1c8d2ad70b90d12b52652030e9a338217719064fdb84b7ad0d693694                                   # [win]
   folder: mklml
 
+build:
+  skip: True  # [not x86_64]
+  skip: True  # [win and vc<14]
+
 outputs:
   - name: libmklml
     script: install-libmklml.sh   # [unix]

--- a/mklml-feedstock/recipe/meta.yaml
+++ b/mklml-feedstock/recipe/meta.yaml
@@ -32,8 +32,11 @@ outputs:
         - /lib/libpthread.so.0
     requirements:
       host:
+        # libmklml_gnu.so: Needed DSO lib/libgomp.so.1
+        - libgcc-ng  # [linux]
         - intel-openmp {{ version }}
       run:
+        - libgcc-ng  # [linux]
         - intel-openmp {{ version }}
   - name: mklml
     build:

--- a/mklml-feedstock/recipe/meta.yaml
+++ b/mklml-feedstock/recipe/meta.yaml
@@ -1,0 +1,50 @@
+{% set long_version="2018.0.3.20180406" %}
+{% set mkldnn_version="0.14" %} # Only for generating url
+{% set version='.'.join(long_version.split('.')[0:3]) %}
+
+package:
+  name: mklml-suite
+  version: {{ version }}
+
+source:
+  url: https://github.com/intel/mkl-dnn/releases/download/v{{ mkldnn_version }}/mklml_lnx_{{ long_version }}.tgz  # [linux]
+  sha256: d2305244fdc9b87db7426ed4496e87a4b3977ad3374d73b8000e8b7a5b7aa725                                   # [linux]
+  url: https://github.com/intel/mkl-dnn/releases/download/v{{ mkldnn_version }}/mklml_mac_{{ long_version }}.tgz  # [osx]
+  sha256: 094e3dfd61c816136dc8d12a45cc611ce26c5f4828176a3644cd0b0efa15a25b                                   # [osx]
+  url: https://github.com/intel/mkl-dnn/releases/download/v{{ mkldnn_version }}/mklml_win_{{ long_version }}.zip  # [win]
+  sha256: a584a5bf1c8d2ad70b90d12b52652030e9a338217719064fdb84b7ad0d693694                                   # [win]
+  folder: mklml
+
+outputs:
+  - name: libmklml
+    script: install-libmklml.sh   # [unix]
+    script: install-libmklml.bat  # [win]
+    build:
+      detect_binary_files_with_prefix: False
+      missing_dso_whitelist:
+        - /lib64/ld-linux-x86-64.so.2
+        - /lib/libm.so.6
+        - /lib/libc.so.6
+        - /lib/libpthread.so.0
+    requirements:
+      host:
+        - intel-openmp {{ version }}
+      run:
+        - intel-openmp {{ version }}
+  - name: mklml
+    build:
+      run_exports:
+        - libmklml >={{ version }}
+    requirements:
+      run:
+        - mkl-include {{ version }}
+        - libmklml {{ version }}
+
+about:
+  home: https://github.com/intel/mkl-dnn/releases
+  license_file: {{ SRC_DIR }}/mklml/license.txt
+  descrition: |
+    MKLML is a subset of MKL and it's built by the MKL release team using
+    standard MKL custom dynamic library builder. It contains smaller number of
+    functions to reduce the size of the download and reduce the number of
+    dynamic libraries user needs.


### PR DESCRIPTION
On macOS, the test `test_lrn_backward` segfaults, but when attached with lldb, it passes. 