### PR TITLE
Add recipe for mxnet

### DIFF
--- a/mxnet-feedstock/recipe/0001-Make-versions-of-python-dependencies-like-numpy-dete.patch
+++ b/mxnet-feedstock/recipe/0001-Make-versions-of-python-dependencies-like-numpy-dete.patch
@@ -1,0 +1,29 @@
+From 71be9def8ecf57f484ecaeeb3c544c57174b9432 Mon Sep 17 00:00:00 2001
+From: Sandeep Krishnamurthy <sandeep.krishna98@gmail.com>
+Date: Mon, 25 Dec 2017 15:39:43 -0800
+Subject: [PATCH 1/7] Make versions of python dependencies like numpy,
+ deterministic. (#9169)
+
+* Make versions of python dependencies like numpy, deterministic.
+
+* Make numpy version dependency fixed between 1.8.2 and 1.13.3. Update install guide with fortran for numpy
+---
+ python/setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/python/setup.py b/python/setup.py
+index 029b3af..b7a8449 100644
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -28,7 +28,7 @@ if "--inplace" in sys.argv:
+ else:
+     from setuptools import setup
+     from setuptools.extension import Extension
+-    kwargs = {'install_requires': ['numpy', 'requests', 'graphviz'], 'zip_safe': False}
++    kwargs = {'install_requires': ['numpy<=1.13.3,>=1.8.2', 'requests==2.18.4', 'graphviz==0.8.1'], 'zip_safe': False}
+ from setuptools import find_packages
+ 
+ with_cython = False
+-- 
+1.9.5 (Apple Git-50.3)
+

--- a/mxnet-feedstock/recipe/0002-Relax-constraints-on-requests-make-graphviz-optional.patch
+++ b/mxnet-feedstock/recipe/0002-Relax-constraints-on-requests-make-graphviz-optional.patch
@@ -1,0 +1,26 @@
+From d90098ad087764d3099c5b6ebfcd0c6c63c475da Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Wed, 27 Dec 2017 07:04:30 -0600
+Subject: [PATCH 2/7] Relax constraints on requests, make graphviz optional
+
+---
+ python/setup.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/python/setup.py b/python/setup.py
+index b7a8449..1dd455e 100644
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -28,7 +28,8 @@ if "--inplace" in sys.argv:
+ else:
+     from setuptools import setup
+     from setuptools.extension import Extension
+-    kwargs = {'install_requires': ['numpy<=1.13.3,>=1.8.2', 'requests==2.18.4', 'graphviz==0.8.1'], 'zip_safe': False}
++    kwargs = {'install_requires': ['numpy<=1.13.3,>=1.8.2', 'requests<3,>=2.18.4'], 'zip_safe': False,
++              'extras_require': {'graphviz': ['graphviz']}}
+ from setuptools import find_packages
+ 
+ with_cython = False
+-- 
+1.9.5 (Apple Git-50.3)
+

--- a/mxnet-feedstock/recipe/0003-OpenCV-Libs-Specify-explicitly.patch
+++ b/mxnet-feedstock/recipe/0003-OpenCV-Libs-Specify-explicitly.patch
@@ -1,0 +1,26 @@
+From 9ea05a5debb6694e2aba8f07a536106b0b104f0d Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Sat, 30 Dec 2017 10:31:40 -0800
+Subject: [PATCH 3/7] OpenCV Libs: Specify explicitly
+
+This will help avoid over linking libraries
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index ceed645..d5f4e39 100644
+--- a/Makefile
++++ b/Makefile
+@@ -95,7 +95,7 @@ endif
+ # setup opencv
+ ifeq ($(USE_OPENCV), 1)
+ 	CFLAGS += -DMXNET_USE_OPENCV=1 $(shell pkg-config --cflags opencv)
+-	LDFLAGS += $(filter-out -lopencv_ts, $(shell pkg-config --libs opencv))
++	LDFLAGS += -lopencv_core -lopencv_imgproc -lopencv_imgcodecs
+ 	BIN += bin/im2rec
+ else
+ 	CFLAGS+= -DMXNET_USE_OPENCV=0
+-- 
+1.9.5 (Apple Git-50.3)
+

--- a/mxnet-feedstock/recipe/0004-Also-attempt-pkg-config-for-jemalloc.patch
+++ b/mxnet-feedstock/recipe/0004-Also-attempt-pkg-config-for-jemalloc.patch
@@ -1,0 +1,36 @@
+From de58d6e8dfd9ab07e19f7f99945a8cfdd672f717 Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Sat, 30 Dec 2017 10:31:40 -0800
+Subject: [PATCH 4/7] Also attempt pkg-config for jemalloc
+
+---
+ Makefile | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index d5f4e39..a87c25d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -208,10 +208,18 @@ ifneq ($(USE_GPERFTOOLS), 1)
+ 				endif
+ 			endif
+ 		endif
++		JEMALLOC_CUSTOM=$(shell pkg-config --exists jemalloc; echo $$?)
++		ifeq ($(JEMALLOC_CUSTOM), 0)
++			CFLAGS += $(shell pkg-config --cflags jemalloc)
++			LDFLAGS += $(shell pkg-config --libs jemalloc)
++			USE_JEMALLOC=1
++		endif
+ 		ifeq ($(USE_JEMALLOC), 1)
+ 			CFLAGS += -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc \
+ 			-fno-builtin-free -DUSE_JEMALLOC
+-			LDFLAGS += $(FIND_LIBFILE)
++			ifneq ($(JEMALLOC_CUSTOM), 0)
++				LDFLAGS += $(FIND_LIBFILE)
++			endif
+ 		endif
+ 	endif
+ endif
+-- 
+1.9.5 (Apple Git-50.3)
+

--- a/mxnet-feedstock/recipe/0005-Check-if-HOME_MKL-is-empty-before-using-it.patch
+++ b/mxnet-feedstock/recipe/0005-Check-if-HOME_MKL-is-empty-before-using-it.patch
@@ -1,0 +1,25 @@
+From d327b42ec334ec20be5968ed3864cbfbda719853 Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Sat, 30 Dec 2017 10:31:58 -0800
+Subject: [PATCH 5/7] Check if $HOME_MKL is empty before using it
+
+---
+ prepare_mkl.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/prepare_mkl.sh b/prepare_mkl.sh
+index 97a1e49..f4632c7 100755
+--- a/prepare_mkl.sh
++++ b/prepare_mkl.sh
+@@ -68,7 +68,7 @@ echo $VERSION_LINE  # Return Version Line
+ 
+ # MKL
+ HOME_MKL=$1
+-if [ ! -d "$HOME_MKL" ]; then
++if [ ! -z "$HOME_MKL" -a ! -d "$HOME_MKL" ]; then
+    mkdir $HOME_MKL
+ fi
+ MXNET_ROOT=`dirname $0`
+-- 
+1.9.5 (Apple Git-50.3)
+

--- a/mxnet-feedstock/recipe/0006-Use-MKL-ML-options-only-if-USE_MKLML-1.patch
+++ b/mxnet-feedstock/recipe/0006-Use-MKL-ML-options-only-if-USE_MKLML-1.patch
@@ -1,0 +1,44 @@
+From 3cb7595ed1bd96aad9fb74d1f434ab57f7e97197 Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Sat, 30 Dec 2017 10:31:59 -0800
+Subject: [PATCH 6/7] Use MKL-ML options only if USE_MKLML=1
+
+---
+ Makefile | 16 ++++++++++------
+ 1 file changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index a87c25d..cf09c2f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -116,17 +116,21 @@ ifeq ($(USE_MKL2017), 1)
+ 	CFLAGS += -DMXNET_USE_MKL2017=1
+ 	CFLAGS += -DUSE_MKL=1
+ 	CFLAGS += -I$(ROOTDIR)/src/operator/mkl/
+-	CFLAGS += -I$(MKLML_ROOT)/include
+-	LDFLAGS += -L$(MKLML_ROOT)/lib
++	ifeq ($(USE_MKLML), 1)
++		CFLAGS += -I$(MKLML_ROOT)/include
++		LDFLAGS += -L$(MKLML_ROOT)/lib
++	endif
+ 	ifeq ($(USE_MKL2017_EXPERIMENTAL), 1)
+ 		CFLAGS += -DMKL_EXPERIMENTAL=1
+ 	else
+ 		CFLAGS += -DMKL_EXPERIMENTAL=0
+ 	endif
+-	ifeq ($(UNAME_S), Darwin)
+-		LDFLAGS += -lmklml
+-	else
+-		LDFLAGS += -Wl,--as-needed -lmklml_intel -lmklml_gnu
++	ifeq ($(USE_MKLML), 1)
++		ifeq ($(UNAME_S), Darwin)
++			LDFLAGS += -lmklml
++		else
++			LDFLAGS += -Wl,--as-needed -lmklml_intel -lmklml_gnu
++		endif
+ 	endif
+ 	LDFLAGS +=  -liomp5
+ endif
+-- 
+1.9.5 (Apple Git-50.3)
+

--- a/mxnet-feedstock/recipe/0007-Prepend-additional-C-LD-FLAGS-instead-of-appending.patch
+++ b/mxnet-feedstock/recipe/0007-Prepend-additional-C-LD-FLAGS-instead-of-appending.patch
@@ -1,0 +1,31 @@
+From ee960789991a1d0d0a1247293be77f2b8174d5bc Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Sat, 30 Dec 2017 10:31:59 -0800
+Subject: [PATCH 7/7] Prepend additional {C,LD}FLAGS instead of appending
+
+Because order matters!
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index cf09c2f..d292ead 100644
+--- a/Makefile
++++ b/Makefile
+@@ -241,11 +241,11 @@ ifeq ($(USE_THREADED_ENGINE), 1)
+ endif
+ 
+ ifneq ($(ADD_CFLAGS), NONE)
+-	CFLAGS += $(ADD_CFLAGS)
++	CFLAGS := $(ADD_CFLAGS) $(CFLAGS)
+ endif
+ 
+ ifneq ($(ADD_LDFLAGS), NONE)
+-	LDFLAGS += $(ADD_LDFLAGS)
++	LDFLAGS := $(ADD_LDFLAGS) $(LDFLAGS)
+ endif
+ 
+ ifneq ($(USE_CUDA_PATH), NONE)
+-- 
+1.9.5 (Apple Git-50.3)
+

--- a/mxnet-feedstock/recipe/install-libmxnet.sh
+++ b/mxnet-feedstock/recipe/install-libmxnet.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Fire all the activation scripts
+source activate "${BUILD_PREFIX}"
+
+set -ex
+
+cp make/config.mk config.mk
+
+for file in Makefile dmlc-core/Makefile nnvm/Makefile
+do
+  # We wish to use the ar from our packages
+  sed -i.bak -e 's/ar cr/$(AR) crv/' $file
+done
+
+export OPENMP_OPT=1
+export JEMALLOC_OPT=1
+
+if [[ ${HOST} =~ .*darwin.* ]]; then
+  cp make/osx.mk config.mk
+  export OPENMP_OPT=0
+  # On macOS, jemalloc defaults to JEMALLOC_PREFIX: 'je_'
+  # for which mxnet source code isn't ready yet.
+  export JEMALLOC_OPT=0
+  export LDFLAGS="${LDFLAGS_CC}"
+fi
+
+export BLAS_OPTS="USE_BLAS=$blas_impl"
+if [[ "${blas_impl}" == "mkl" ]]; then
+  BLAS_OPTS="${BLAS_OPTS} USE_STATIC_MKL=NONE USE_INTEL_PATH=NONE USE_MKL2017=1"
+  export MKLROOT="${PREFIX}"
+fi
+
+make -j${CPU_COUNT} \
+  AR="$AR" \
+  CC="$CC" \
+  CXX="$CXX" \
+  USE_CUDA=0 \
+  USE_CUDNN=0 \
+  USE_OPENCV=1 \
+  USE_LAPACK=1 \
+  ${BLAS_OPTS} \
+  USE_PROFILER=1 \
+  USE_CPP_PACKAGE=1 \
+  USE_SIGNAL_HANDLER=1 \
+  ADD_CFLAGS="$CFLAGS" \
+  ADD_LDFLAGS="$LDFLAGS" \
+  USE_OPENMP="$OPENMP_OPT" \
+  USE_JEMALLOC="$JEMALLOC_OPT" \
+  VERBOSE=${VERBOSE_AT}
+
+mkdir -p $PREFIX/bin
+cp bin/* $PREFIX/bin/
+
+mkdir -p $PREFIX/include
+cp -rv include/* $PREFIX/include/
+cp -rv dmlc-core/include/* $PREFIX/include/
+cp -rv nnvm/include/* $PREFIX/include/
+
+# https://github.com/apache/incubator-mxnet/tree/1.0.0/cpp-package
+cp -rv cpp-package/include/mxnet-cpp $PREFIX/include/mxnet-cpp
+
+cp -rv lib/* $PREFIX/lib/

--- a/mxnet-feedstock/recipe/install-py-mxnet.sh
+++ b/mxnet-feedstock/recipe/install-py-mxnet.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Fire all the activation scripts
+source activate "${BUILD_PREFIX}"
+
+set -x
+
+cd python
+${PYTHON} setup.py install --with-cython --single-version-externally-managed --record=record.txt
+
+# Delete the copied libmxnet.so and create a relative symlink to $PREFIX/lib/
+# The build scripts produce .so even on osx
+find ${PREFIX} | grep libmxnet.so | grep -v $PREFIX/lib/libmxnet.so | xargs rm -f
+ln -sf ../../../libmxnet.so $SP_DIR/mxnet/libmxnet.so

--- a/mxnet-feedstock/recipe/meta.yaml
+++ b/mxnet-feedstock/recipe/meta.yaml
@@ -1,0 +1,110 @@
+package:
+  name: mxnet-mkl
+  version: 1.0.0
+
+build:
+  skip: True  # [win]
+  # conda > 4.4 might be able to use this
+  requires_features:
+    blas: {{ blas_impl }}
+  # this is for conda 4.4 and below
+  features:
+    - nomkl    # [x86 and blas_impl != 'mkl']
+
+source:
+  git_rev: 1.0.0
+  git_url: https://github.com/apache/incubator-mxnet.git
+  patches:
+    - 0001-Make-versions-of-python-dependencies-like-numpy-dete.patch
+    - 0002-Relax-constraints-on-requests-make-graphviz-optional.patch
+    - 0003-OpenCV-Libs-Specify-explicitly.patch
+    - 0004-Also-attempt-pkg-config-for-jemalloc.patch
+    - 0005-Check-if-HOME_MKL-is-empty-before-using-it.patch
+    - 0006-Use-MKL-ML-options-only-if-USE_MKLML-1.patch
+    - 0007-Prepend-additional-C-LD-FLAGS-instead-of-appending.patch
+
+outputs:
+  - name: libmxnet
+    script: install-libmxnet.sh  # [unix]
+    requirements:
+      host:
+        - jemalloc  # [linux]
+        - mkl-devel  {{ mkl }}  # [blas_impl == 'mkl']
+        - openblas-devel {{ openblas }}  # [blas_impl == 'openblas']
+        - opencv
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - pkg-config
+        - make
+      # Run exports will take care of opencv, mkl, jemalloc
+    test:
+      commands:
+        - im2rec -h
+        - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+        - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+      requires: # [x86 and blas_impl != 'mkl']
+        - nomkl # [x86 and blas_impl != 'mkl']
+
+  - name: py-mxnet
+    script: install-py-mxnet.sh  # [unix]
+    requirements:
+      host:
+        - libmxnet
+        - cython
+        - python
+        # Numpy's C API is not used
+        - numpy >=1.8.2,<=1.13.3
+        - requests >=2.18.4,<3
+        - {{ pin_subpackage('libmxnet', exact=True) }}
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      run:
+        - python
+        - {{ pin_subpackage('libmxnet', exact=True) }}
+        # https://github.com/apache/incubator-mxnet/pull/9169
+        - numpy >=1.8.2,<=1.13.3
+        - requests >=2.18.4,<3
+        # This is only required for visualization and hence optional.
+        # We need a new build of graphviz otherwise it downgrades opencv
+        #- python-graphviz
+    test:
+      imports:
+        - mxnet
+      requires: # [x86 and blas_impl != 'mkl']
+        - nomkl # [x86 and blas_impl != 'mkl']
+      script: test-py-mxnet.py
+
+  - name: mxnet
+    requirements:
+      host:
+        - python
+      run:
+        - {{ pin_subpackage('libmxnet', exact=True) }}
+        - {{ pin_subpackage('py-mxnet', exact=True) }}
+        - python
+
+about:
+  home: http://mxnet.io
+  license: Apache-2
+  license_file: LICENSE
+  license_family: Apache
+  summary: MXNet is a deep learning framework designed for both efficiency and flexibility
+  description: |
+    Apache MXNet (incubating) is a deep learning framework designed for both
+    efficiency and flexibility. It allows you to mix symbolic and imperative
+    programming to maximize efficiency and productivity. At its core, MXNet
+    contains a dynamic dependency scheduler that automatically parallelizes both
+    symbolic and imperative operations on the fly. A graph optimization layer on
+    top of that makes symbolic execution fast and memory efficient. MXNet is
+    portable and lightweight, scaling effectively to multiple GPUs and multiple
+    machines. MXNet is also more than a deep learning project. It is also a
+    collection of blue prints and guidelines for building deep learning systems,
+    and interesting insights of DL systems for hackers.
+  dev_url: https://github.com/apache/incubator-mxnet
+  doc_url: https://mxnet.incubator.apache.org/
+
+extra:
+  recipe-maintainers:
+    - nehaljwani

--- a/mxnet-feedstock/recipe/test-py-mxnet.py
+++ b/mxnet-feedstock/recipe/test-py-mxnet.py
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import numpy as np
+import mxnet as mx
+
+class WeightedLogisticRegression(mx.operator.CustomOp):
+    def __init__(self, pos_grad_scale, neg_grad_scale):
+        self.pos_grad_scale = float(pos_grad_scale)
+        self.neg_grad_scale = float(neg_grad_scale)
+    def forward(self, is_train, req, in_data, out_data, aux):
+        self.assign(out_data[0], req[0], mx.nd.divide(1, (1 + mx.nd.exp(- in_data[0]))))
+    def backward(self, req, out_grad, in_data, out_data, in_grad, aux):
+        in_grad[0][:] = ((out_data[0] - 1) * in_data[1] * self.pos_grad_scale
+                         + out_data[0] * (1 - in_data[1]) * self.neg_grad_scale) / out_data[0].shape[1]
+
+@mx.operator.register("weighted_logistic_regression")
+class WeightedLogisticRegressionProp(mx.operator.CustomOpProp):
+    def __init__(self, pos_grad_scale, neg_grad_scale):
+        self.pos_grad_scale = pos_grad_scale
+        self.neg_grad_scale = neg_grad_scale
+        super(WeightedLogisticRegressionProp, self).__init__(False)
+    def list_arguments(self):
+        return ['data', 'label']
+    def list_outputs(self):
+        return ['output']
+    def infer_shape(self, in_shape):
+        shape = in_shape[0]
+        return [shape, shape], [shape]
+    def create_operator(self, ctx, shapes, dtypes):
+        return WeightedLogisticRegression(self.pos_grad_scale, self.neg_grad_scale)
+
+if __name__ == '__main__':
+    m, n = 2, 5
+    pos, neg = 1, 0.1
+    data = mx.sym.Variable('data')
+
+    wlr = mx.sym.Custom(data, pos_grad_scale=pos, neg_grad_scale=neg, name='wlr',
+                        op_type='weighted_logistic_regression')
+    lr = mx.sym.LogisticRegressionOutput(data, name='lr')
+
+    # MXNET_CPU_WORKER_NTHREADS must be greater than 1 for custom op to work on CPU
+    context = mx.cpu()
+    # Uncomment this line to compute on GPU
+    # context=mx.gpu(0)
+
+    exe1 = wlr.simple_bind(ctx=context, data=(2 * m, n))
+    exe2 = lr.simple_bind(ctx=context, data=(2 * m, n))
+
+    exe1.arg_dict['data'][:] = np.ones([2 * m, n])
+    exe2.arg_dict['data'][:] = np.ones([2 * m, n])
+
+    exe1.arg_dict['wlr_label'][:] = np.vstack([np.ones([m, n]), np.zeros([m, n])])
+    exe2.arg_dict['lr_label'][:] = np.vstack([np.ones([m, n]), np.zeros([m, n])])
+
+    exe1.forward(is_train=True)
+    exe2.forward(is_train=True)
+
+    print('Weighted Logistic Regression output:')
+    print(exe1.outputs[0].asnumpy())
+
+    print('Logistic Regression output:')
+    print(exe2.outputs[0].asnumpy())
+
+    exe1.backward()
+    exe2.backward()
+
+    print('Weighted Logistic Regression gradients:')
+    print(exe1.grad_dict['data'].asnumpy())
+
+    print('Logistic Regression gradients:')
+    print(exe2.grad_dict['data'].asnumpy())


### PR DESCRIPTION
- This is for *nix only.
- The build on macOS hasn't been compiled with openmp
- Since we don't have an up to date version of {python-,}graphviz at the moment, installing {python-,}graphviz in the same environment will not be possible, as they will conflict with the dependencies of the latest opencv with which this package will be built. To work around that, we'll need to build it with opencv 3.1.0 and opencv 3.3.1

I spent some time to include the nomkl variant, but it is quite hard to get it right with split packages at the moment, so I'll submit a separate recipe for that, with the feedstock name: mxnet-nomkl
