### PR TITLE
pytorch: lazy symbol binding for cpu support

### DIFF
--- a/pytorch-feedstock/recipe/README
+++ b/pytorch-feedstock/recipe/README
@@ -14,11 +14,11 @@ To build a conda pytorch package with GPU support
 
 * Update conda and conda-build, and navigate to the recipe root folder.
 
-    Modify conda_build_config.yaml in this directory to specifiy the
+    Modify conda_build_config.yaml in this directory to specify the
     CUDA, CuDNN, and python versions.
 
     To start a build use:
 
     ```
-    conda build --no-test .
+    conda build .
     ```

--- a/pytorch-feedstock/recipe/lazy_bind_C_extension.patch
+++ b/pytorch-feedstock/recipe/lazy_bind_C_extension.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index bfac6914e..09e2fb231 100644
+--- a/setup.py
++++ b/setup.py
+@@ -567,7 +567,7 @@ C = Extension("torch._C",
+               extra_compile_args=main_compile_args + extra_compile_args,
+               include_dirs=include_dirs,
+               library_dirs=library_dirs,
+-              extra_link_args=extra_link_args + main_link_args + [make_relative_rpath('lib')],
++              extra_link_args=extra_link_args + main_link_args + ['-Wl,-z,lazy'] + [make_relative_rpath('lib')],
+               )
+ extensions.append(C)
+ 

--- a/pytorch-feedstock/recipe/meta.yaml
+++ b/pytorch-feedstock/recipe/meta.yaml
@@ -10,11 +10,15 @@ source:
   git_tag: {{ commit }}
   patches:
     - 0001-force-system-nccl.patch
+    # When run on a system without a GPU, PyTorch does not require the CUDA
+    # libraries. Therefore symbols should not be resolved at load time rather
+    # resolution should be defered until the function is called (lazy binding).
+    - lazy_bind_C_extension.patch
     # https://github.com/pytorch/pytorch/issues/4499
     - define_speed_unknown.patch
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: False
 
 requirements:
@@ -53,7 +57,6 @@ test:
     - test
   commands:
     - ./test/run_test.sh
-    - conda inspect linkages -p $PREFIX pytorch
 
 about:
   home: http://pytorch.org/


### PR DESCRIPTION
Enable lazy symbol binding for CPU support