### PR TITLE
centralize build number for gcc & activation to associate with gcc ver

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -34,7 +34,7 @@ fortran_compiler_version:
   - 16.0.4                     # [win]
 # matrix on linux, because the ABI breaks at GCC 8
   - 7.3.0                      # [linux]
-  # - 8.2.0                      # [linux]
+  - 8.2.0                      # [linux]
 CONDA_BUILD_SYSROOT:
   - /opt/MacOSX10.9.sdk        # [osx]
 VERBOSE_AT:
@@ -49,8 +49,19 @@ ctng_binutils:
   - 2.31.1
 ctng_duma:
   - 2.5.15
+
 ctng_gcc:
   - 7.3.0
+  - 8.2.0
+# keep zip_keys in mind - these are coupled with a specific gcc version in the ctng_gcc above
+ctng_gcc_build_number:
+  - 1
+  - 2
+# keep zip_keys in mind - these are coupled with a specific gcc version in the ctng_gcc above
+ctng_gcc_activation_build_number:
+  - 3
+  - 1
+
 ctng_gmp:
   - 6.1.2
 ctng_isl:
@@ -212,3 +223,7 @@ zip_keys:
     - cxx_compiler              # [win]
     - fortran_compiler_version  # [win]
     - python                    # [win]
+  -
+    - ctng_gcc
+    - ctng_gcc_build_number
+    - ctng_gcc_activation_build_number

--- a/ctng-compilers-activation-feedstock/recipe/meta.yaml
+++ b/ctng-compilers-activation-feedstock/recipe/meta.yaml
@@ -6,7 +6,8 @@ source:
   path: .
 
 build:
-  number: 3
+  # defined in conda_build_config.yaml so that we can keep it associated with a particular GCC version number
+  number: {{ ctng_gcc_activation_build_num }}
 
 requirements:
   build:

--- a/ctng-compilers-feedstock/recipe/meta.yaml
+++ b/ctng-compilers-feedstock/recipe/meta.yaml
@@ -1,5 +1,3 @@
-{% set build_num = 1 %}
-
 package:
   name: compilers_{{ ctng_target_platform }}
   version: {{ ctng_gcc }}
@@ -9,7 +7,8 @@ source:
 
 build:
   merge_build_host: False
-  number: {{ build_num }}
+  # defined in conda_build_config.yaml so that we can keep it associated with a particular GCC version number
+  number: {{ ctng_gcc_build_num }}
   # The CentOS6 system libraries should be used for everything here.
   # We do not have CDT packages yet, nor compilers that would use them!
   missing_dso_whitelist:


### PR DESCRIPTION
This is to facilitate the building/maintaining of several different gcc versions at once.  Without this, we had to re-set the build number for each different gcc version we maintained, and it was/is a mess.