### PR TITLE
Add pin_compatible to nccl for pytorch recipe

### DIFF
--- a/pytorch-feedstock/recipe/meta.yaml
+++ b/pytorch-feedstock/recipe/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     # GPU requirements
     - cudatoolkit {{ cudatoolkit }}*
     - cudnn {{ cudnn }}*
-    - nccl
+    - {{ pin_compatible('nccl') }}
     # other requirements
     - python
     - {{ pin_compatible('numpy') }}


### PR DESCRIPTION
I have an environment in which nccl 2 is available. The pytorch build is compatible only with libnccls of the same major version that it was built against (see #82). Right now, since nccl 2 is not available in any of the continuum repositories, this means that the distributed pytorch builds are only compatible with nccl 1. Since there is no pin on nccl in the pytorch recipe, "conda create -n foo pytorch" gives me pytorch and nccl 2, which causes pytorch to fail at import time. This patch resolves the issue.