### PR TITLE
Complete virtualization of the compiler environments on Windows

### DIFF
--- a/vs2008/install_activate.bat
+++ b/vs2008/install_activate.bat
@@ -13,3 +13,5 @@ IF "%cross_compiler_target_platform%" == "win-64" (
   )
 
 echo CALL "%%VSINSTALLDIR%%\..\..\VC\vcvarsall.bat" %target_platform% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+echo set INCLUDE=%%INCLUDE%%;%%LIBRARY_INC%% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+echo set LIB=%%LIB%%;%%LIBRARY_LIB%% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"

--- a/vs2010/install_activate.bat
+++ b/vs2010/install_activate.bat
@@ -13,3 +13,5 @@ IF "%cross_compiler_target_platform%" == "win-64" (
   )
 
 echo CALL "%%VSINSTALLDIR%%\..\..\VC\vcvarsall.bat" %target_platform% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+echo set INCLUDE=%%INCLUDE%%;%%LIBRARY_INC%% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+echo set LIB=%%LIB%%;%%LIBRARY_LIB%% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"

--- a/vs2015/install_activate.bat
+++ b/vs2015/install_activate.bat
@@ -13,3 +13,5 @@ IF "%cross_compiler_target_platform%" == "win-64" (
   )
 
 echo CALL "%%VSINSTALLDIR%%..\..\VC\vcvarsall.bat" %target_platform% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+echo set INCLUDE=%%INCLUDE%%;%%LIBRARY_INC%% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+echo set LIB=%%LIB%%;%%LIBRARY_LIB%% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"

--- a/vs2017/install_activate.bat
+++ b/vs2017/install_activate.bat
@@ -3,18 +3,18 @@ set VER=15
 
 mkdir "%PREFIX%\etc\conda\activate.d"
 COPY "%RECIPE_DIR%\activate.bat" "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+echo pushd "%%VSINSTALLDIR%%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 
 IF "%cross_compiler_target_platform%" == "win-64" (
   set "target_platform=amd64"
   echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR% Win64" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-  echo pushd "%%VSINSTALLDIR%%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   echo CALL "VC\Auxiliary\Build\vcvars64.bat" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-  echo popd >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   ) else (
   set "target_platform=x86"
   echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-  echo pushd "%%VSINSTALLDIR%%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   echo CALL "VC\Auxiliary\Build\vcvars32.bat" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-  echo popd >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   )
 
+echo popd >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+echo set INCLUDE=%%INCLUDE%%;%%LIBRARY_INC%% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+echo set LIB=%%LIB%%;%%LIBRARY_LIB%% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"


### PR DESCRIPTION
It aligns user experience with conda compilers on all the platforms since [unix] compilers set CPPFLAGS and LDFLAGS to include PREFIX for include and library directories 