### PR TITLE
Fix & align VS2017 environment with the rest of VS (may change some binaries!)

### DIFF
--- a/vs2015/activate.bat
+++ b/vs2015/activate.bat
@@ -38,8 +38,6 @@ set "MSYS2_ENV_CONV_EXCL=CL"
 set "PY_VCRUNTIME_REDIST=%PREFIX%\vcruntime140.dll"
 
 :: ensure that we use the DLL part of the ucrt
-set "CFLAGS=%CFLAGS% -MD -GL"
-set "CXXFLAGS=%CXXFLAGS% -MD -GL"
 set "LDFLAGS_SHARED=%LDFLAGS_SHARED% -LTCG ucrt.lib"
 
 :: translate target platform


### PR DESCRIPTION
No other VS* environment exports -MD flag to the environment. It also causes conflict if a package compiles debug binaries like in https://github.com/conda-forge/tbb-feedstock/issues/36
Also, /MD is used by default, so, there is no reason to supply it