### PR TITLE
llvm-compilers: bump version to 7.0.0

### DIFF
--- a/llvm-compilers-feedstock/recipe/0001-clang-Allow-disabling-libXML.patch
+++ b/llvm-compilers-feedstock/recipe/0001-clang-Allow-disabling-libXML.patch
@@ -1,23 +1,35 @@
+From 6110ab24d1b87fc7d4255377d6302670000c138c Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Sat, 25 Aug 2018 09:19:11 -0500
+Subject: [PATCH 1/3] clang: Allow disabling libXML
+
+---
+ CMakeLists.txt | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2ce621c04b8a9ddf290b027efb985bd83aa653ff..63a041e48427b0b475e9868c7c8ef7b93baa1abf 100644
+index 52b8819..e19ace6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -180,10 +180,15 @@
- # we can include cmake files from this directory.
- list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
- 
--find_package(LibXml2 2.5.3 QUIET)
--if (LIBXML2_FOUND)
--  set(CLANG_HAVE_LIBXML 1)
+@@ -188,10 +188,15 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+ # code may call MSan interceptors like strlen, leading to false positives.
+ if(NOT LLVM_USE_SANITIZER MATCHES "Memory.*")
+   set (LIBXML2_FOUND 0)
+-  find_package(LibXml2 2.5.3 QUIET)
+-  if (LIBXML2_FOUND)
+-    set(CLANG_HAVE_LIBXML 1)
 +# @LOCALMOD-BEGIN
-+option(CLANG_ENABLE_LIBXML "Enable libXML" ON)
-+if (CLANG_ENABLE_LIBXML)
-+  find_package(LibXml2)
-+  if (LIBXML2_FOUND)
-+    set(CLANG_HAVE_LIBXML 1)
-+  endif()
- endif()
++  option(CLANG_ENABLE_LIBXML "Enable libXML" ON)
++  if (CLANG_ENABLE_LIBXML)
++    find_package(LibXml2)
++    if (LIBXML2_FOUND)
++      set(CLANG_HAVE_LIBXML 1)
++    endif()
+   endif()
 +# @LOCALMOD-END
+ endif()
  
  include(CheckIncludeFile)
- check_include_file(sys/resource.h CLANG_HAVE_RLIMITS)
+-- 
+2.5.4 (Apple Git-61)
+

--- a/llvm-compilers-feedstock/recipe/0002-clang-add-conda-specific-env-var-CONDA_BUILD_SYSROOT.patch
+++ b/llvm-compilers-feedstock/recipe/0002-clang-add-conda-specific-env-var-CONDA_BUILD_SYSROOT.patch
@@ -1,7 +1,18 @@
-diff -urN clang.orig/lib/Driver/Driver.cpp clang/lib/Driver/Driver.cpp
---- clang.orig/lib/Driver/Driver.cpp	2017-08-10 15:45:56.000000000 -0700
-+++ clang/lib/Driver/Driver.cpp	2017-08-10 15:58:21.000000000 -0700
-@@ -614,8 +614,13 @@
+From 7565075efc6ba701dc5a6d0ba7667658dac5d3d9 Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Sat, 25 Aug 2018 09:20:04 -0500
+Subject: [PATCH 2/3] clang: add conda specific env var CONDA_BUILD_SYSROOT
+
+---
+ lib/Driver/Driver.cpp             | 9 +++++++--
+ lib/Frontend/InitHeaderSearch.cpp | 6 +++++-
+ 2 files changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/lib/Driver/Driver.cpp b/lib/Driver/Driver.cpp
+index 952a716..67e4917 100644
+--- a/lib/Driver/Driver.cpp
++++ b/lib/Driver/Driver.cpp
+@@ -971,8 +971,13 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
      A->claim();
      PrefixDirs.push_back(A->getValue(0));
    }
@@ -16,11 +27,12 @@ diff -urN clang.orig/lib/Driver/Driver.cpp clang/lib/Driver/Driver.cpp
 +  }
    if (const Arg *A = Args.getLastArg(options::OPT__dyld_prefix_EQ))
      DyldPrefix = A->getValue();
-   if (Args.hasArg(options::OPT_nostdlib))
-diff -urN clang.orig/lib/Frontend/InitHeaderSearch.cpp clang/lib/Frontend/InitHeaderSearch.cpp
---- clang.orig/lib/Frontend/InitHeaderSearch.cpp	2017-08-10 14:57:35.000000000 -0700
-+++ clang/lib/Frontend/InitHeaderSearch.cpp	2017-08-10 16:19:14.000000000 -0700
-@@ -26,6 +26,7 @@
+ 
+diff --git a/lib/Frontend/InitHeaderSearch.cpp b/lib/Frontend/InitHeaderSearch.cpp
+index 8a70404..b1c5f55 100644
+--- a/lib/Frontend/InitHeaderSearch.cpp
++++ b/lib/Frontend/InitHeaderSearch.cpp
+@@ -27,6 +27,7 @@
  #include "llvm/ADT/Twine.h"
  #include "llvm/Support/ErrorHandling.h"
  #include "llvm/Support/Path.h"
@@ -28,8 +40,8 @@ diff -urN clang.orig/lib/Frontend/InitHeaderSearch.cpp clang/lib/Frontend/InitHe
  #include "llvm/Support/raw_ostream.h"
  
  using namespace clang;
-@@ -223,7 +224,10 @@
-         break;
+@@ -228,7 +229,10 @@ void InitHeaderSearch::AddDefaultCIncludePaths(const llvm::Triple &triple,
+       LLVM_FALLTHROUGH;
      default:
        // FIXME: temporary hack: hard-coded paths.
 -      AddPath("/usr/local/include", System, false);
@@ -40,3 +52,6 @@ diff -urN clang.orig/lib/Frontend/InitHeaderSearch.cpp clang/lib/Frontend/InitHe
        break;
      }
    }
+-- 
+2.5.4 (Apple Git-61)
+

--- a/llvm-compilers-feedstock/recipe/0003-clang-Fix-normalizeProgramName-s-handling-of-dots-ou.patch
+++ b/llvm-compilers-feedstock/recipe/0003-clang-Fix-normalizeProgramName-s-handling-of-dots-ou.patch
@@ -1,4 +1,4 @@
-From f6435ab717124ed533968b3f657fd9024aa80e69 Mon Sep 17 00:00:00 2001
+From 810992794396fbd34349bf1dac9a9fe38a4d5020 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 30 Aug 2017 20:01:49 +0100
 Subject: [PATCH 3/3] Fix normalizeProgramName()'s handling of dots outside of
@@ -18,18 +18,18 @@ x86_64-apple-darwin13.4
  1 file changed, 22 insertions(+), 1 deletion(-)
 
 diff --git a/lib/Driver/ToolChain.cpp b/lib/Driver/ToolChain.cpp
-index 6adc0386ee..d2b582c7f7 100644
+index cf3db34..31b093b 100644
 --- a/lib/Driver/ToolChain.cpp
 +++ b/lib/Driver/ToolChain.cpp
-@@ -31,6 +31,7 @@ using namespace clang::driver::tools;
- using namespace clang;
+@@ -49,6 +49,7 @@ using namespace driver;
+ using namespace tools;
  using namespace llvm;
  using namespace llvm::opt;
 +using namespace llvm::sys::path;
  
  static llvm::opt::Arg *GetRTTIArgument(const ArgList &Args) {
    return Args.getLastArg(options::OPT_mkernel, options::OPT_fapple_kext,
-@@ -124,10 +125,30 @@ const DriverSuffix *FindDriverSuffix(StringRef ProgName) {
+@@ -154,10 +155,30 @@ static const DriverSuffix *FindDriverSuffix(StringRef ProgName, size_t &Pos) {
    return nullptr;
  }
  
@@ -55,12 +55,12 @@ index 6adc0386ee..d2b582c7f7 100644
 +
  /// Normalize the program name from argv[0] by stripping the file extension if
  /// present and lower-casing the string on Windows.
- std::string normalizeProgramName(llvm::StringRef Argv0) {
+ static std::string normalizeProgramName(llvm::StringRef Argv0) {
 -  std::string ProgName = llvm::sys::path::stem(Argv0);
 +  std::string ProgName = program_name_stem(Argv0);
- #ifdef LLVM_ON_WIN32
+ #ifdef _WIN32
    // Transform to lowercase for case insensitive file systems.
    std::transform(ProgName.begin(), ProgName.end(), ProgName.begin(), ::tolower);
 -- 
-2.14.1
+2.5.4 (Apple Git-61)
 

--- a/llvm-compilers-feedstock/recipe/0003-compiler-rt-Make-7.0.0-compatible-with-10.9-SDK.patch
+++ b/llvm-compilers-feedstock/recipe/0003-compiler-rt-Make-7.0.0-compatible-with-10.9-SDK.patch
@@ -1,0 +1,72 @@
+From eaa09b0ac70d1ebba29c4650cb5e5c14b9049499 Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Tue, 16 Oct 2018 21:23:44 -0500
+Subject: [PATCH 3/3] compiler-rt: Make 7.0.0 compatible with 10.9 SDK
+
+---
+ lib/xray/xray_buffer_queue.h |  7 +++++++
+ lib/xray/xray_utils.h        | 30 ++++++++++++++++++++++++++++++
+ 2 files changed, 37 insertions(+)
+
+diff --git a/lib/xray/xray_buffer_queue.h b/lib/xray/xray_buffer_queue.h
+index e76fa79..e20a69a 100644
+--- a/lib/xray/xray_buffer_queue.h
++++ b/lib/xray/xray_buffer_queue.h
+@@ -20,6 +20,13 @@
+ #include "sanitizer_common/sanitizer_mutex.h"
+ #include <cstddef>
+ 
++#include <sys/mman.h>
++/* MAP_ANONYMOUS is MAP_ANON on some systems,
++   e.g. OS X (before Sierra), OpenBSD etc */
++#if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
++#define MAP_ANONYMOUS MAP_ANON
++#endif
++
+ namespace __xray {
+ 
+ /// BufferQueue implements a circular queue of fixed sized buffers (much like a
+diff --git a/lib/xray/xray_utils.h b/lib/xray/xray_utils.h
+index eafa16e..a8dad83 100644
+--- a/lib/xray/xray_utils.h
++++ b/lib/xray/xray_utils.h
+@@ -20,6 +20,36 @@
+ #include <sys/types.h>
+ #include <utility>
+ 
++#if defined __APPLE__
++#include <time.h>
++#include <mach/clock.h>
++#include <mach/mach.h>
++int alt_clock_gettime(int clock_id, timespec *ts) {
++  clock_serv_t cclock;
++  mach_timespec_t mts;
++  host_get_clock_service(mach_host_self(), clock_id, &cclock);
++  clock_get_time(cclock, &mts);
++  mach_port_deallocate(mach_task_self(), cclock);
++  ts->tv_sec = mts.tv_sec;
++  ts->tv_nsec = mts.tv_nsec;
++  return 0;
++}
++#include <sys/mman.h>
++/* MAP_ANONYMOUS is MAP_ANON on some systems,
++   e.g. OS X (before Sierra), OpenBSD etc */
++#if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
++#define MAP_ANONYMOUS MAP_ANON
++#endif
++
++#if defined __APPLE__ && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 // less than macOS 10.12
++  #define clock_gettime alt_clock_gettime
++  #define CLOCK_REALTIME CALENDAR_CLOCK
++  #define CLOCK_MONOTONIC SYSTEM_CLOCK
++  typedef int clockid_t;
++#endif
++
++#endif
++
+ namespace __xray {
+ 
+ // Default implementation of the reporting interface for sanitizer errors.
+-- 
+2.5.4 (Apple Git-61)
+

--- a/llvm-compilers-feedstock/recipe/420-ld64-autoconfiscate.patch
+++ b/llvm-compilers-feedstock/recipe/420-ld64-autoconfiscate.patch
@@ -1,4 +1,4 @@
-diff -urN ld64.orig/APPLE_LICENSE ld64/APPLE_LICENSE
+700-ld64-drop-tapi-support.patch700-ld64-drop-tapi-support.patchdiff -urN ld64.orig/APPLE_LICENSE ld64/APPLE_LICENSE
 --- ld64.orig/APPLE_LICENSE	2017-08-07 16:57:31.870787702 +0100
 +++ ld64/APPLE_LICENSE	2017-08-07 17:26:48.949898951 +0100
 @@ -364,4 +364,4 @@
@@ -70,7 +70,7 @@ diff -urN ld64.orig/Makefile.in ld64/Makefile.in
 +                  -DSUPPORT_ARCH_armv7em=1 -DSUPPORT_ARCH_armv8=1 -DSUPPORT_ARCH_arm64=1 -DSUPPORT_ARCH_arm64v8=1
 +
 +MYLDFLAGS       = -L$(top_builddir)/libstuff
-+MYLIBS          = -lstuff $(UUID_LIBS) $(DL_LIBS) $(LTO_LIBS) -ltapi -lxar $(SSL_LIBS)
++MYLIBS          = -lstuff $(UUID_LIBS) $(DL_LIBS) $(LTO_LIBS) -lxar $(SSL_LIBS)
 +
 +MYCOMPILEFLAGS  = $(WARNINGS) $(MYWARNINGS) $(DEFS) $(MYDEFS) \
 +                  $(CPPFLAGS) $(MYINCLUDES) $(CFLAGS) $(MDYNAMICNOPIC)

--- a/llvm-compilers-feedstock/recipe/700-ld64-drop-tapi-support.patch
+++ b/llvm-compilers-feedstock/recipe/700-ld64-drop-tapi-support.patch
@@ -1,0 +1,120 @@
+From 998513e7e9b0122bb8054f2ee63f70797b9f4d44 Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Fri, 19 Oct 2018 07:54:06 +0530
+Subject: [PATCH] 700 ld64 drop tapi support
+
+Wait for proper resolution that comes from
+http://lists.llvm.org/pipermail/llvm-dev/2018-September/126472.html
+---
+ src/ld/InputFiles.cpp                  | 10 +++++-----
+ src/ld/Options.cpp                     | 22 +++++++++++-----------
+ src/ld/parsers/textstub_dylib_file.cpp |  3 ++-
+ 3 files changed, 18 insertions(+), 17 deletions(-)
+
+diff --git a/src/ld/InputFiles.cpp b/src/ld/InputFiles.cpp
+index 9e06514..d1881b8 100644
+--- a/src/ld/InputFiles.cpp
++++ b/src/ld/InputFiles.cpp
+@@ -58,7 +58,7 @@
+ #include "InputFiles.h"
+ #include "macho_relocatable_file.h"
+ #include "macho_dylib_file.h"
+-#include "textstub_dylib_file.hpp"
++//#include "textstub_dylib_file.hpp"
+ #include "archive_file.h"
+ #include "lto_file.h"
+ #include "opaque_section_file.h"
+@@ -331,10 +331,10 @@ ld::File* InputFiles::makeFile(const Options::FileInfo& info, bool indirectDylib
+ 			if ( dylibResult != NULL ) {
+ 				return dylibResult;
+ 			}
+-			dylibResult = textstub::dylib::parse(p, len, info.path, info.modTime, _options, info.ordinal, info.options.fBundleLoader, indirectDylib);
+-			if ( dylibResult != NULL ) {
+-				return dylibResult;
+-			}
++//			dylibResult = textstub::dylib::parse(p, len, info.path, info.modTime, _options, info.ordinal, info.options.fBundleLoader, indirectDylib);
++//			if ( dylibResult != NULL ) {
++//				return dylibResult;
++//			}
+ 			break;
+ 		case Options::kStaticExecutable:
+ 		case Options::kDyld:
+diff --git a/src/ld/Options.cpp b/src/ld/Options.cpp
+index ae20932..1b66d35 100644
+--- a/src/ld/Options.cpp
++++ b/src/ld/Options.cpp
+@@ -34,7 +34,7 @@
+ #include <spawn.h>
+ #include <cxxabi.h>
+ #include <Availability.h>
+-#include <tapi/tapi.h>
++//#include <tapi/tapi.h>
+ 
+ #include <vector>
+ #include <map>
+@@ -833,10 +833,10 @@ bool Options::findFile(const std::string &path, const std::vector<std::string> &
+ 
+ 	// If we found a text-based stub file, check if it should be used.
+ 	if ( !tbdInfo.missing() ) {
+-		if (tapi::LinkerInterfaceFile::shouldPreferTextBasedStubFile(tbdInfo.path)) {
+-			result = tbdInfo;
+-			return true;
+-		}
++//		if (tapi::LinkerInterfaceFile::shouldPreferTextBasedStubFile(tbdInfo.path)) {
++//			result = tbdInfo;
++//			return true;
++//		}
+ 	}
+ 	FileInfo dylibInfo;
+ 	{
+@@ -858,15 +858,15 @@ bool Options::findFile(const std::string &path, const std::vector<std::string> &
+ 	// There are both - a text-based stub file and a dynamic library file.
+ 	else if ( !tbdInfo.missing() && !dylibInfo.missing() ) {
+ 		// If the files are still in synv we can use and should use the text-based stub file.
+-		if (tapi::LinkerInterfaceFile::areEquivalent(tbdInfo.path, dylibInfo.path)) {
+-			result = tbdInfo;
+-		}
++//		if (tapi::LinkerInterfaceFile::areEquivalent(tbdInfo.path, dylibInfo.path)) {
++//			result = tbdInfo;
++//		}
+ 		// Otherwise issue a warning and fall-back to the dynamic library file.
+-		else {
++//		else {
+ 			warning("text-based stub file %s and library file %s are out of sync. Falling back to library file for linking.", tbdInfo.path, dylibInfo.path);
+ 			result = dylibInfo;
+ 
+-		}
++//		}
+ 		return true;
+ 	}
+ 
+@@ -3970,7 +3970,7 @@ void Options::buildSearchPaths(int argc, const char* argv[])
+ 				const char* ltoVers = lto::version();
+ 				if ( ltoVers != NULL )
+ 					fprintf(stderr, "LTO support using: %s\n", ltoVers);
+-				fprintf(stderr, "TAPI support using: %s\n", tapi::Version::getFullVersionAsString().c_str());
++//				fprintf(stderr, "TAPI support using: %s\n", tapi::Version::getFullVersionAsString().c_str());
+ 				exit(0);
+ 			}
+ 		}
+diff --git a/src/ld/parsers/textstub_dylib_file.cpp b/src/ld/parsers/textstub_dylib_file.cpp
+index 4613154..fc98eef 100644
+--- a/src/ld/parsers/textstub_dylib_file.cpp
++++ b/src/ld/parsers/textstub_dylib_file.cpp
+@@ -22,7 +22,7 @@
+  * @APPLE_LICENSE_HEADER_END@
+  */
+ 
+-
++#if 0
+ #include <sys/param.h>
+ #include <sys/mman.h>
+ #include <tapi/tapi.h>
+@@ -282,3 +282,4 @@ ld::dylib::File* parse(const uint8_t* fileContent, uint64_t fileLength, const ch
+ 	
+ } // namespace dylib
+ } // namespace textstub
++#endif
+-- 
+2.17.1 (Apple Git-112)
+

--- a/llvm-compilers-feedstock/recipe/build.sh
+++ b/llvm-compilers-feedstock/recipe/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 
 # Ensure we do not end up linking to a shared libz
 rm -f "${PREFIX}"/lib/libz*${SHLIB_EXT}
@@ -146,7 +147,6 @@ _cctools_config+=(--disable-static)
 _cctools_config+=(--enable-shared)
 
 if [[ ! -f ${PREFIX}/bin/${DARWIN_TARGET}-ld ]]; then
-
   # libtool on macOS 10.9 is too old to build LLVM statically:
   # CMakeFiles/LLVMSupport.dir/PluginLoader.cpp.o is not an object file (not allowed in a library)
   # https://trac.macports.org/ticket/54129
@@ -193,17 +193,19 @@ if [[ ! -f ${PREFIX}/bin/${DARWIN_TARGET}-ld ]]; then
       popd
     popd
     # TODO :: Tapi breaks when making cross-compilers.
-    if [[ ! -f ${PREFIX}/lib/libtapi${SHLIB_EXT} ]]; then
-      [[ -d llvm_tapi_build ]] || mkdir llvm_tapi_build
-      pushd llvm_tapi_build
-        cmake -G'Unix Makefiles'                                 \
-              -C ../projects/tapi/cmake/caches/apple-tapi.cmake  \
-              "${_cmake_config[@]}"                              \
-              -DCMAKE_LIBTOOL=${BOOTSTRAP}/bin/libtool           \
-              ..
-        make -j${CPU_COUNT} ${VERBOSE_CM} install-distribution
-      popd
-    fi
+#    if [[ ! -f ${PREFIX}/lib/libtapi${SHLIB_EXT} ]]; then
+#      [[ -d llvm_tapi_build ]] || mkdir llvm_tapi_build
+#      pushd llvm_tapi_build
+#        cmake -G'Unix Makefiles'                                 \
+#              -C ../projects/tapi/cmake/caches/apple-tapi.cmake  \
+#              "${_cmake_config[@]}"                              \
+#              -DCMAKE_LIBTOOL=${BOOTSTRAP}/bin/libtool           \
+#              -DCLANG_TABLEGEN_EXE=${PWD}/bin/clang-tblgen       \
+#              -DLLVM_TARGETS_TO_BUILD=all                        \
+#              ..
+#        make -j${CPU_COUNT} ${VERBOSE_CM} install-distribution
+#      popd
+#    fi
   fi
   [[ -d cctools_build ]] || mkdir cctools_build
   pushd cctools_build
@@ -247,8 +249,8 @@ export PATH=${PREFIX}/bin:${OLD_PATH}
 if [[ ! -f cctools_build_final/ld64/ld ]]; then
   [[ -d cctools_build_final ]] || mkdir cctools_build_final
   pushd cctools_build_final
-    CC=${PREFIX}/bin/clang" ${CFLAG_SYSROOT}"     \
-    CXX=${PREFIX}/bin/clang++" ${CFLAG_SYSROOT}"  \
+    CC=${PREFIX}/bin/clang                        \
+    CXX=${PREFIX}/bin/clang++                     \
       ../cctools/configure                        \
         "${_cctools_config[@]}"                   \
         --prefix=${PREFIX}                        \

--- a/llvm-compilers-feedstock/recipe/conda_build_config.macOS_10.9.yaml
+++ b/llvm-compilers-feedstock/recipe/conda_build_config.macOS_10.9.yaml
@@ -7,7 +7,7 @@ target_platform:
 cross_target_platform:
   - osx-64
 compiler_ver:
-  - 4.0.1
+  - 7.0.0
 library_type:
   - shared
 FINAL_CPPFLAGS:

--- a/llvm-compilers-feedstock/recipe/install-llvm-lto.sh
+++ b/llvm-compilers-feedstock/recipe/install-llvm-lto.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+. activate "${PREFIX}"
+PATH=${PREFIX}/cmake-bin/bin:${PATH}
+cd "${SRC_DIR}"
+
+DEST="${PWD}"/install-llvm-lto-tapi
+[[ -d "${DEST}" ]] && rm -rf "${DEST}"
+pushd llvm_build_final/tools/lto
+  make install DESTDIR="${DEST}"
+popd
+#pushd llvm_build_final/projects/tapi
+#  make install DESTDIR="${DEST}"
+#popd
+pushd "${DEST}"/"${PWD}"/prefix
+  cp -Rf * "${PREFIX}"
+popd

--- a/llvm-compilers-feedstock/recipe/meta.yaml
+++ b/llvm-compilers-feedstock/recipe/meta.yaml
@@ -2,20 +2,21 @@
 # in order to bootstrap the compilers so they do not depend on system libs (libc++)
 
 {% set releases_url="releases" %}
-{% set version="4.0.1" %}
-{% set version_dash="4.0.1" %}
-{% set version_dir="4.0.1" %}
-{% set llvm_sha256 = 'da783db1f82d516791179fe103c71706046561f7972b18f0049242dee6712b51' %}
-{% set cfe_sha256 = '61738a735852c23c3bdbe52d035488cdb2083013f384d67c1ba36fabebd8769b' %}
-{% set polly_sha256 = 'b443bb9617d776a7d05970e5818aa49aa2adfb2670047be8e9f242f58e84f01a' %}
-{% set compiler_rt_sha256 = 'a3c87794334887b93b7a766c507244a7cdcce1d48b2e9249fc9a94f2c3beb440' %}
-{% set libcxx_sha256 = '520a1171f272c9ff82f324d5d89accadcec9bc9f3c78de11f5575cdb99accc4c' %}
-{% set libcxxabi_sha256 = '8f08178989a06c66cd19e771ff9d8ca526dd4a23d1382d63e416c04ea9fa1b33' %}
-{% set libunwind_sha256 = '3b072e33b764b4f9b5172698e080886d1f4d606531ab227772a7fc08d6a92555' %}
-{% set openmp_sha256 = 'ec693b170e0600daa7b372240a06e66341ace790d89eaf4a843e8d56d5f4ada4' %}
+{% set version="7.0.0" %}
+{% set bootstrap_version_dir="7.0.0" %}
+{% set bootstrap_version_dash="7.0.0" %}
+{% set version_dir="7.0.0" %}
+{% set llvm_sha256 = '8bc1f844e6cbde1b652c19c1edebc1864456fd9c78b8c1bea038e51b363fe222' %}
+{% set cfe_sha256 = '550212711c752697d2f82c648714a7221b1207fd9441543ff4aa9e3be45bba55' %}
+{% set polly_sha256 = '919810d3249f4ae79d084746b9527367df18412f30fe039addbf941861c8534b' %}
+{% set compiler_rt_sha256 = 'bdec7fe3cf2c85f55656c07dfb0bd93ae46f2b3dd8f33ff3ad6e7586f4c670d6' %}
+{% set libcxx_sha256 = '9b342625ba2f4e65b52764ab2061e116c0337db2179c6bce7f9a0d70c52134f0'%}
+{% set libcxxabi_sha256 = '9b45c759ff397512eae4d938ff82827b1bd7ccba49920777e5b5e460baeb245f' %}
+{% set libunwind_sha256 = '50aee87717421e70450f1e093c6cd9a27f2b111025e1e08d64d5ace36e338a9c' %}
+{% set openmp_sha256 = '30662b632f5556c59ee9215c1309f61de50b3ea8e89dcc28ba9a9494bba238ff' %}
 # It looks like this got changed at some point.
 # {% set clang_llvm_bin_sha256 = '5ef4f1f72d0fe4cf03d8eaefb972b4d24219da67124a869ae75e3a6aeb1578f6' %}
-{% set clang_llvm_bin_sha256 = '5f697801a46239c04251730b7ccccd3ebbacb9043ad381a061ae6812409e9eae' %}
+{% set clang_llvm_bin_sha256 = 'b3ad93c3d69dfd528df9c5bb1a434367babb8f3baea47fbb99bf49f1b03c94ca' %}
 
 # {% set releases_url="prereleases" %}
 # {% set version="5.0.0rc5" %}
@@ -71,9 +72,8 @@ source:
     folder: projects/compiler-rt
     sha256: {{ compiler_rt_sha256 }}
     patches:
-      - 0001-cmake-Cache-results-of-find_darwin_sdk_dir.patch
-      # - 0001-5.0.0-cmake-Cache-results-of-find_darwin_sdk_dir.patch
       - 0002-compiler-rt-Determine-COMPILER_RT_SUPPORTED_ARCH-eve.patch
+      - 0003-compiler-rt-Make-7.0.0-compatible-with-10.9-SDK.patch
   - url: http://{{ releases_url }}.llvm.org/{{ version_dir }}/libunwind-{{ version }}.src.tar.xz
     sha256: {{ libunwind_sha256 }}
     folder: projects/libunwind
@@ -86,15 +86,23 @@ source:
   - url: http://{{ releases_url }}.llvm.org/{{ version_dir }}/openmp-{{ version }}.src.tar.xz
     sha256: {{ openmp_sha256 }}
     folder: projects/openmp
-  - url: https://opensource.apple.com/tarballs/tapi/tapi-{{ tapi_version }}.tar.gz
-    sha256: {{ tapi_sha256 }}
-    folder: projects/tapi
-    patches:
-      - 0001-tapi-llvm-4.0.1-compat-remove-TimeValue-header-include.patch 
-      - 0002-tapi-llvm-4.0.1-compat-add-missing-StringSwitch-include.patch
-      - 0003-tapi-llvm-4.0.1-compat-modernise-error-handling.patch        
-      - 0004-tapi-cross-compat.patch
-      # - 0005-tapi-5.0.0-Move-Support-MachO-to-BinaryFormat-MachO.patch
+#  - git_url: https://github.com/ributzka/tapi
+#    git_rev: b9205695b4edee91000383695be8de5ba8e0db41
+#    folder: projects/tapi
+#    patches:
+#       - 0001-tapi-llvm-7.0.0-Use-PRIVATE-in-target_link_libraries.patch
+#       - 0002-tapi-llvm-7.0.0-Use-add_llvm_install_targets.patch
+#  - url: https://opensource.apple.com/tarballs/tapi/tapi-{{ tapi_version }}.tar.gz
+#    sha256: {{ tapi_sha256 }}
+#    folder: projects/tapi
+#    patches:
+#      - 0001-tapi-llvm-4.0.1-compat-remove-TimeValue-header-include.patch
+#      - 0002-tapi-llvm-4.0.1-compat-add-missing-StringSwitch-include.patch
+#      - 0003-tapi-llvm-4.0.1-compat-modernise-error-handling.patch
+#      - 0004-tapi-cross-compat.patch
+#      - 0005-Use-add_llvm_install_targets-for-creating-install-ta.patch
+#      - 0005-tapi-5.0.0-Move-Support-MachO-to-BinaryFormat-MachO.patch
+#      - 0001-llvm-sys-fs-file_magic-llvm-file_magic.patch
   - url: https://opensource.apple.com/tarballs/cctools/cctools-{{ cctools_version }}.tar.gz
     sha256: {{ cctools_sha256 }}
     folder: cctools
@@ -145,8 +153,9 @@ source:
       - 510-ld64-fix-incorrect-fname-case.patch
       - 520-ld64-fix-usr-local-and-usr-ordering.patch
       - 530-ld64-add-conda-specific-env-vars-to-modify-lib-search-paths.patch
+      - 700-ld64-drop-tapi-support.patch
     # Because macOS 10.9's clang is too old (problems with atomics)
-  - url: http://{{ releases_url }}.llvm.org/{{ version_dir }}/clang+llvm-{{ version_dash }}-x86_64-apple-darwin.tar.xz       [osx]
+  - url: http://{{ releases_url }}.llvm.org/{{ bootstrap_version_dir }}/clang+llvm-{{ bootstrap_version_dash }}-x86_64-apple-darwin.tar.xz       [osx]
     sha256: {{ clang_llvm_bin_sha256 }}
     folder: bootstrap                                                                                     [osx]
   # We copy headers necessary for building cctools/ld64 from dyld and MacOSX10.9.sdk (on all OSes).
@@ -157,6 +166,9 @@ source:
   - url: https://github.com/phracker/MacOSX-SDKs/releases/download/MacOSX10.11.sdk/MacOSX10.9.sdk.tar.xz
     sha256: {{ macosx_109_sdk_sha256 }}
     folder: bootstrap/MacOSX10.9.sdk
+
+build:
+  number: 0
 
 requirements:
   build:
@@ -180,8 +192,8 @@ requirements:
     - zlib
 
 outputs:
-  - name: llvm-lto-tapi
-    script: install-llvm-lto-tapi.sh
+  - name: llvm-lto
+    script: install-llvm-lto.sh
     requirements:
       build:
         - cmake-binary
@@ -215,9 +227,9 @@ outputs:
     script: install-ld64.sh
     requirements:
       build:
-        - {{ pin_subpackage('llvm-lto-tapi', exact=True) }}
+        - {{ pin_subpackage('llvm-lto', exact=True) }}
       run:
-        - {{ pin_subpackage('llvm-lto-tapi', exact=True) }}
+        - {{ pin_subpackage('llvm-lto', exact=True) }}
         # Normally, this dep would be injected via run_exports by the jinja2 compiler() function
         # but that is not possible when bootstrapping as it would cause a build dependency cycle.
         - {{ pin_subpackage('libcxx', exact=True) }}        # [osx]
@@ -237,7 +249,7 @@ outputs:
       build:
         - cmake-binary
       run:
-        - {{ pin_subpackage('llvm-lto-tapi', exact=True) }}
+        - {{ pin_subpackage('llvm-lto', exact=True) }}
         # Normally, this dep would be injected via run_exports by the jinja2 compiler() function
         # but that is not possible when bootstrapping as it would cause a build dependency cycle.
         - {{ pin_subpackage('libcxx', exact=True) }}        # [osx]


### PR DESCRIPTION
- Rebase clang patches
- Add patches to compiler-rt to support older SDK
- Drop support for tapi until it builds with upstream llvm
  xref: http://lists.llvm.org/pipermail/llvm-dev/2018-September/126472.html
  xref: https://github.com/tpoechtrager/osxcross/issues/103
- Rename llvm-lto-tapi to llvm-lto
- Drop CFLAG_SYSROOT when using non-bootstrap compiler for final build
  of cctools
- Drop patches already upstreamed
- Specify build number explicitly