### PR TITLE
ENH enable -ffast-math

### DIFF
--- a/gfortran-feedstock/recipe/meta.yaml
+++ b/gfortran-feedstock/recipe/meta.yaml
@@ -13,7 +13,7 @@ package:
   version: {{ gfortran_ver }}
 
 build:
-  number: 6
+  number: 7
   skip: True                                                  # [not osx]
   binary_has_prefix_files:
     - lib/libgcc_ext.10.*.dylib

--- a/gfortran-feedstock/recipe/meta.yaml
+++ b/gfortran-feedstock/recipe/meta.yaml
@@ -31,6 +31,9 @@ build:
     # For -fopenmp:
     - lib/libgomp.spec
 
+    # For -ffast-math
+    - lib/gcc/{{ chost }}/{{ gfortran_ver }}/crtfastmath.o
+
     # For -static:
     - lib/libgfortran.a
     - lib/libgomp.a


### PR DESCRIPTION
@isuruf @mingwandroid @msarahan

I went ahead and made a PR to fix this since some of the conda-forge rebuilds are failing due to this missing file. IDK if this is the right spot, but it seems like it. 