### PR TITLE
pin up to 4 for libgfortran

### DIFF
--- a/gfortran-feedstock/recipe/meta.yaml
+++ b/gfortran-feedstock/recipe/meta.yaml
@@ -7,7 +7,7 @@
 {% set chost = "x86_64-apple-darwin11.4.2" %}
 {% set gfortran_ver = "4.8.5" %}
 {% set libgfortran_ver = "3.0.1" %}
-{% set max_libgfortran_ver = "4.0.1" %}
+{% set max_libgfortran_ver = "4.0.0.a0" %}
 
 package:
   name: gfortran_{{ target_platform }}

--- a/gfortran-feedstock/recipe/meta.yaml
+++ b/gfortran-feedstock/recipe/meta.yaml
@@ -14,7 +14,7 @@ package:
   version: {{ gfortran_ver }}
 
 build:
-  number: 7
+  number: 8
   skip: True                                                  # [not osx]
   binary_has_prefix_files:
     - lib/libgcc_ext.10.*.dylib

--- a/gfortran-feedstock/recipe/meta.yaml
+++ b/gfortran-feedstock/recipe/meta.yaml
@@ -7,6 +7,7 @@
 {% set chost = "x86_64-apple-darwin11.4.2" %}
 {% set gfortran_ver = "4.8.5" %}
 {% set libgfortran_ver = "3.0.1" %}
+{% set max_libgfortran_ver = "4.0.1" %}
 
 package:
   name: gfortran_{{ target_platform }}
@@ -62,13 +63,13 @@ build:
 
   run_exports:
     strong:
-      - libgfortran >={{ libgfortran_ver }}
+      - libgfortran >={{ libgfortran_ver }},<{{ max_libgfortran_ver }}
 
 requirements:
   build:
     - gcc {{ gfortran_ver }}
   run:
-    - libgfortran >={{ libgfortran_ver }}
+    - libgfortran >={{ libgfortran_ver }},<{{ max_libgfortran_ver }}
 
 about:
   home: http://gcc.gnu.org/


### PR DESCRIPTION
This PR adjust the libgfortran pinning to include 3.01 to 4.0.0.a0 (not including 4). Once conda-forge ships an updated gfortran, this will be needed. 

@msarahan @isuruf @mingwandroid for viz