### PR TITLE
Fix batch cmd bug

### DIFF
--- a/vs2017/install_activate.bat
+++ b/vs2017/install_activate.bat
@@ -6,19 +6,18 @@ COPY "%RECIPE_DIR%\activate.bat" "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compile
 
 IF "%cross_compiler_target_platform%" == "win-64" (
   set "target_platform=amd64"
-  echo IF "%%CMAKE_GENERATOR%%" == "" ( >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-  echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR% Win64" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-  echo ) >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+  set "CMAKE_GENERATOR=Visual Studio %VER% %YEAR% Win64"
   echo pushd "%%VSINSTALLDIR%%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   echo CALL "VC\Auxiliary\Build\vcvars64.bat" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   echo popd >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-  ) else (
+) else (
   set "target_platform=x86"
-  echo IF "%%CMAKE_GENERATOR%%" == "" ( >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-  echo SET "CMAKE_GENERATOR=Visual Studio %VER% %YEAR%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-  echo ) >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+  set "CMAKE_GENERATOR=Visual Studio %VER% %YEAR%"
   echo pushd "%%VSINSTALLDIR%%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   echo CALL "VC\Auxiliary\Build\vcvars32.bat" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   echo popd >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-  )
+)
 
+echo IF "%%CMAKE_GENERATOR%%" == "" ( >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+echo SET "CMAKE_GENERATOR=%CMAKE_GENERATOR%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+echo ) >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"

--- a/vs2017/install_activate.bat
+++ b/vs2017/install_activate.bat
@@ -7,16 +7,16 @@ COPY "%RECIPE_DIR%\activate.bat" "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compile
 IF "%cross_compiler_target_platform%" == "win-64" (
   set "target_platform=amd64"
   set "CMAKE_GENERATOR=Visual Studio %VER% %YEAR% Win64"
-  echo pushd "%%VSINSTALLDIR%%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-  echo CALL "VC\Auxiliary\Build\vcvars64.bat" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-  echo popd >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+  set "bits=64"
 ) else (
   set "target_platform=x86"
   set "CMAKE_GENERATOR=Visual Studio %VER% %YEAR%"
-  echo pushd "%%VSINSTALLDIR%%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-  echo CALL "VC\Auxiliary\Build\vcvars32.bat" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-  echo popd >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+  set "bits=32"
 )
+
+echo pushd "%%VSINSTALLDIR%%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+echo CALL "VC\Auxiliary\Build\vcvars%bits%.bat" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+echo popd >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 
 echo IF "%%CMAKE_GENERATOR%%" == "" ( >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 echo SET "CMAKE_GENERATOR=%CMAKE_GENERATOR%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"

--- a/vs2017/install_activate.bat
+++ b/vs2017/install_activate.bat
@@ -7,15 +7,15 @@ COPY "%RECIPE_DIR%\activate.bat" "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compile
 IF "%cross_compiler_target_platform%" == "win-64" (
   set "target_platform=amd64"
   set "CMAKE_GENERATOR=Visual Studio %VER% %YEAR% Win64"
-  set "bits=64"
+  set "BITS=64"
 ) else (
   set "target_platform=x86"
   set "CMAKE_GENERATOR=Visual Studio %VER% %YEAR%"
-  set "bits=32"
+  set "BITS=32"
 )
 
 echo pushd "%%VSINSTALLDIR%%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-echo CALL "VC\Auxiliary\Build\vcvars%bits%.bat" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
+echo CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 echo popd >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 
 echo IF "%%CMAKE_GENERATOR%%" == "" ( >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"

--- a/vs2017/meta.yaml
+++ b/vs2017/meta.yaml
@@ -13,7 +13,7 @@ package:
 
 build:
   skip: True  [not win]
-  number: 3
+  number: 4
 
 outputs:
   - name: vs{{ vsyear }}_{{ cross_compiler_target_platform }}


### PR DESCRIPTION
With many writes to the activation script inside the if block, an error
occurs saying file is busy and then the if else block gets messed up.

Fixes https://github.com/conda/conda/issues/8610