### PR TITLE
Make vs2015 not break the environment if a compiler is missing

### DIFF
--- a/vs2015/activate.bat
+++ b/vs2015/activate.bat
@@ -21,8 +21,8 @@ if "%VSINSTALLDIR%" == "" (
 )
 
 if "%VSINSTALLDIR%" == "" (
-   ECHO "Did not find VS in registry or in VS140COMNTOOLS env var - exiting"
-   exit 1
+   ECHO "WARNING: Did not find VS in registry or in VS140COMNTOOLS env var - your compiler may not work"
+   exit 0
 )
 
 echo "Found VS2014 at %VSINSTALLDIR%"

--- a/vs2015/activate.bat
+++ b/vs2015/activate.bat
@@ -22,7 +22,6 @@ if "%VSINSTALLDIR%" == "" (
 
 if "%VSINSTALLDIR%" == "" (
    ECHO "WARNING: Did not find VS in registry or in VS140COMNTOOLS env var - your compiler may not work"
-   exit 0
 )
 
 echo "Found VS2014 at %VSINSTALLDIR%"

--- a/vs2015/activate.bat
+++ b/vs2015/activate.bat
@@ -22,6 +22,7 @@ if "%VSINSTALLDIR%" == "" (
 
 if "%VSINSTALLDIR%" == "" (
    ECHO "WARNING: Did not find VS in registry or in VS140COMNTOOLS env var - your compiler may not work"
+   GOTO End
 )
 
 echo "Found VS2014 at %VSINSTALLDIR%"
@@ -74,3 +75,5 @@ IF NOT "%CONDA_BUILD%" == "" (
 )
 
 :: other things added by install_activate.bat at package build time
+
+:End


### PR DESCRIPTION
Right now, making a Conda environment that pulls in (intentionally or not) the compiler plumbing on Windows fails if the compiler cannot be found on the system (the plumbing to find the compiler is also fragile and often even if VisualStudio is installed, the specific registry keys and env vars it looks for are not present, making this worse). This diff adjusts the activate scripts for the vs2015 glue so they don't exit early if the compiler cannot be found - they just warn that the compiler may not be present.

For environments that actually need the compiler, this diff gives the user a fully-constructed environment they can try to fix (making a new environment with `conda env create` will otherwise half-make the environment, fail, and then fail to back out leaving them with nothing they can try to fix and, worse, something they must  clean up manually). For environments that don't (where the plumbing is only pulled in by a package that will never in practice use the compiler (e.g. someone pulling in keras which pulls in theano even though many keras people don't want to use theano), this is a full fix.