### PR TITLE
Don't break on VS2008 or VS2010 build, if compiler isn't present

### DIFF
--- a/vs2008/activate.bat
+++ b/vs2008/activate.bat
@@ -21,8 +21,8 @@ if "%VSINSTALLDIR%" == "" (
 )
 
 if "%VSINSTALLDIR%" == "" (
-   ECHO "Did not find VS in registry or in VS90COMNTOOLS env var - exiting"
-   exit 1
+   ECHO "WARNING: Did not find VS in registry or in VS90COMNTOOLS env var - your compiler may not work"
+   GOTO End
 )
 
 echo "Found VS2008 at"
@@ -42,3 +42,5 @@ IF NOT "%CONDA_BUILD%" == "" (
 )
 
 :: other things added by install_activate.bat at package build time
+
+:End

--- a/vs2010/activate.bat
+++ b/vs2010/activate.bat
@@ -23,8 +23,8 @@ if "%VSINSTALLDIR%" == "" (
 )
 
 if "%VSINSTALLDIR%" == "" (
-   ECHO "Did not find VS in registry or in VS90COMNTOOLS env var - exiting"
-   exit 1
+   ECHO "WARNING: Did not find VS in registry or in VS90COMNTOOLS env var - your compiler may not work"
+   goto End
 )
 
 echo "Found VS2010 at"
@@ -48,3 +48,5 @@ if "%ARCH%" == "64" (
 
 set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
 set "MSYS2_ENV_CONV_EXCL=CL"
+
+:End

--- a/vs2015/install_runtime.bat
+++ b/vs2015/install_runtime.bat
@@ -13,8 +13,10 @@ FOR /F "usebackq tokens=3*" %%A IN (`REG QUERY "HKEY_LOCAL_MACHINE\Software\Micr
 if not "%SP%" == "%PKG_VERSION%" (
    echo "Version detected from registry: %SP%"
    echo    "does not match version of package being built (%PKG_VERSION%)"
-   echo "Do you have current updates for VS 2015 installed?"
-   exit 1
+   if "%SP%" LSS "%PGK_VERSION%" (
+     echo "Do you have current updates for VS 2015 installed?"
+     exit 1
+   )
 )
 
 

--- a/vs2015/install_runtime.bat
+++ b/vs2015/install_runtime.bat
@@ -13,10 +13,8 @@ FOR /F "usebackq tokens=3*" %%A IN (`REG QUERY "HKEY_LOCAL_MACHINE\Software\Micr
 if not "%SP%" == "%PKG_VERSION%" (
    echo "Version detected from registry: %SP%"
    echo    "does not match version of package being built (%PKG_VERSION%)"
-   if "%SP%" LSS "%PGK_VERSION%" (
-     echo "Do you have current updates for VS 2015 installed?"
-     exit 1
-   )
+   echo "Do you have current updates for VS 2015 installed?"
+   exit 1
 )
 
 


### PR DESCRIPTION
Additionally allow build of VS2015 with more recent version as described in meta.yaml too.