### PR TITLE
Move away from setting HOST in ctng-activation scripts

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -65,8 +65,8 @@ ctng_gcc_build_number:
   - 2
 # keep zip_keys in mind - these are coupled with a specific gcc version in the ctng_gcc above
 ctng_gcc_activation_build_num:
-  - 8
-  - 4
+  - 9
+  - 5
 
 ctng_gmp:
   - 6.1.2

--- a/ctng-compilers-activation-feedstock/recipe/activate-binutils.sh
+++ b/ctng-compilers-activation-feedstock/recipe/activate-binutils.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -97,7 +106,8 @@ fi
 
 _tc_activation \
   activate host @CHOST@ @CHOST@- \
-  addr2line ar as c++filt elfedit gprof ld ${GOLD_USED} nm objcopy objdump ranlib readelf size strings strip
+  addr2line ar as c++filt elfedit gprof ld ${GOLD_USED} nm objcopy objdump ranlib readelf size strings strip \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-compilers-activation-feedstock/recipe/activate-g++.sh
+++ b/ctng-compilers-activation-feedstock/recipe/activate-g++.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -102,7 +111,8 @@ _tc_activation \
   activate host @CHOST@ @CHOST@- \
   c++ g++ \
   "CXXFLAGS,${CXXFLAGS:-${CXXFLAGS_USED}}" \
-  "DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-${DEBUG_CXXFLAGS_USED}}"
+  "DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-${DEBUG_CXXFLAGS_USED}}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-compilers-activation-feedstock/recipe/activate-gcc.sh
+++ b/ctng-compilers-activation-feedstock/recipe/activate-gcc.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -145,7 +154,8 @@ _tc_activation \
   "DEBUG_CPPFLAGS,${DEBUG_CPPFLAGS:-${DEBUG_CPPFLAGS_USED}}" \
   "DEBUG_CFLAGS,${DEBUG_CFLAGS:-${DEBUG_CFLAGS_USED}}" \
   "CMAKE_PREFIX_PATH,${CMAKE_PREFIX_PATH:-${CMAKE_PREFIX_PATH_USED}}" \
-  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}"
+  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-compilers-activation-feedstock/recipe/activate-gfortran.sh
+++ b/ctng-compilers-activation-feedstock/recipe/activate-gfortran.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -103,6 +112,7 @@ _tc_activation \
   "FORTRANFLAGS,${FORTRANFLAGS:-${FFLAGS_USED}}" \
   "DEBUG_FFLAGS,${FFLAGS:-${FFLAGS_USED} @DEBUG_FFLAGS@}" \
   "DEBUG_FORTRANFLAGS,${FORTRANFLAGS:-${FFLAGS_USED} @DEBUG_FFLAGS@}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 # extra ones - have a dependency on the previous ones, so done after.
 _tc_activation \

--- a/ctng-compilers-activation-feedstock/recipe/deactivate-binutils.sh
+++ b/ctng-compilers-activation-feedstock/recipe/deactivate-binutils.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -97,7 +106,8 @@ fi
 
 _tc_activation \
   deactivate host @CHOST@ @CHOST@- \
-  addr2line ar as c++filt elfedit gprof ld ${GOLD_USED} nm objcopy objdump ranlib readelf size strings strip
+  addr2line ar as c++filt elfedit gprof ld ${GOLD_USED} nm objcopy objdump ranlib readelf size strings strip \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-compilers-activation-feedstock/recipe/deactivate-g++.sh
+++ b/ctng-compilers-activation-feedstock/recipe/deactivate-g++.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -102,7 +111,8 @@ _tc_activation \
   deactivate host @CHOST@ @CHOST@- \
   c++ g++ \
   "CXXFLAGS,${CXXFLAGS:-${CXXFLAGS_USED}}" \
-  "DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-${DEBUG_CXXFLAGS_USED}}"
+  "DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-${DEBUG_CXXFLAGS_USED}}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-compilers-activation-feedstock/recipe/deactivate-gcc.sh
+++ b/ctng-compilers-activation-feedstock/recipe/deactivate-gcc.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -114,7 +123,8 @@ _tc_activation \
   "DEBUG_CPPFLAGS,${DEBUG_CPPFLAGS:-${DEBUG_CPPFLAGS_USED}}" \
   "DEBUG_CFLAGS,${DEBUG_CFLAGS:-${DEBUG_CFLAGS_USED}}" \
   "CMAKE_PREFIX_PATH,${CMAKE_PREFIX_PATH:-${CMAKE_PREFIX_PATH_USED}}" \
-  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}"
+  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-compilers-activation-feedstock/recipe/deactivate-gfortran.sh
+++ b/ctng-compilers-activation-feedstock/recipe/deactivate-gfortran.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -103,6 +112,7 @@ _tc_activation \
   "FORTRANFLAGS,${FORTRANFLAGS:-${FFLAGS_USED}}" \
   "DEBUG_FFLAGS,${FFLAGS:-${FFLAGS_USED} @DEBUG_FFLAGS@}" \
   "DEBUG_FORTRANFLAGS,${FORTRANFLAGS:-${FFLAGS_USED} @DEBUG_FFLAGS@}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 # extra ones - have a dependency on the previous ones, so done after.
 _tc_activation \

--- a/ctng-dbg-compilers-activation-feedstock/recipe/activate-binutils.sh
+++ b/ctng-dbg-compilers-activation-feedstock/recipe/activate-binutils.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -97,7 +106,8 @@ fi
 
 _tc_activation \
   activate host @CHOST@ @CHOST@- \
-  addr2line ar as c++filt elfedit gprof ld ${GOLD_USED} nm objcopy objdump ranlib readelf size strings strip
+  addr2line ar as c++filt elfedit gprof ld ${GOLD_USED} nm objcopy objdump ranlib readelf size strings strip \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-dbg-compilers-activation-feedstock/recipe/activate-g++.sh
+++ b/ctng-dbg-compilers-activation-feedstock/recipe/activate-g++.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -102,7 +111,8 @@ _tc_activation \
   activate host @CHOST@ @CHOST@- \
   c++ g++ \
   "CXXFLAGS,${CXXFLAGS:-${DEBUG_CXXFLAGS_USED}}" \
-  "OPT_CXXFLAGS,${OPT_CXXFLAGS:-${CXXFLAGS_USED}}"
+  "OPT_CXXFLAGS,${OPT_CXXFLAGS:-${CXXFLAGS_USED}}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-dbg-compilers-activation-feedstock/recipe/activate-gcc.sh
+++ b/ctng-dbg-compilers-activation-feedstock/recipe/activate-gcc.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -139,7 +148,8 @@ _tc_activation \
   "LDFLAGS,${LDFLAGS:-${LDFLAGS_USED}}" \
   "OPT_CPPFLAGS,${CPPFLAGS:-${CPPFLAGS_USED}}" \
   "OPT_CFLAGS,${CFLAGS:-${CFLAGS_USED}}" \
-  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}"
+  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-dbg-compilers-activation-feedstock/recipe/activate-gfortran.sh
+++ b/ctng-dbg-compilers-activation-feedstock/recipe/activate-gfortran.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -103,6 +112,7 @@ _tc_activation \
   "FORTRANFLAGS,${FFLAGS:-${FFLAGS_USED} @DEBUG_FFLAGS@}" \
   "OPT_FFLAGS,${FFLAGS:-${FFLAGS_USED}}" \
   "OPT_FORTRANFLAGS,${FFLAGS:-${FFLAGS_USED}}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 # extra ones - have a dependency on the previous ones, so done after.
 _tc_activation \

--- a/ctng-dbg-compilers-activation-feedstock/recipe/deactivate-binutils.sh
+++ b/ctng-dbg-compilers-activation-feedstock/recipe/deactivate-binutils.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -97,7 +106,8 @@ fi
 
 _tc_activation \
   deactivate host @CHOST@ @CHOST@- \
-  addr2line ar as c++filt elfedit gprof ld ${GOLD_USED} nm objcopy objdump ranlib readelf size strings strip
+  addr2line ar as c++filt elfedit gprof ld ${GOLD_USED} nm objcopy objdump ranlib readelf size strings strip \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-dbg-compilers-activation-feedstock/recipe/deactivate-g++.sh
+++ b/ctng-dbg-compilers-activation-feedstock/recipe/deactivate-g++.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -102,7 +111,8 @@ _tc_activation \
   deactivate host @CHOST@ @CHOST@- \
   c++ g++ \
   "CXXFLAGS,${CXXFLAGS:-${DEBUG_CXXFLAGS_USED}}" \
-  "OPT_CXXFLAGS,${OPT_CXXFLAGS:-${CXXFLAGS_USED}}"
+  "OPT_CXXFLAGS,${OPT_CXXFLAGS:-${CXXFLAGS_USED}}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-dbg-compilers-activation-feedstock/recipe/deactivate-gcc.sh
+++ b/ctng-dbg-compilers-activation-feedstock/recipe/deactivate-gcc.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -108,7 +117,8 @@ _tc_activation \
   "LDFLAGS,${LDFLAGS:-${LDFLAGS_USED}}" \
   "OPT_CPPFLAGS,${CPPFLAGS:-${CPPFLAGS_USED}}" \
   "OPT_CFLAGS,${CFLAGS:-${CFLAGS_USED}}" \
-  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}"
+  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-dbg-compilers-activation-feedstock/recipe/deactivate-gfortran.sh
+++ b/ctng-dbg-compilers-activation-feedstock/recipe/deactivate-gfortran.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -103,6 +112,7 @@ _tc_activation \
   "FORTRANFLAGS,${FFLAGS:-${FFLAGS_USED} @DEBUG_FFLAGS@}" \
   "OPT_FFLAGS,${FFLAGS:-${FFLAGS_USED}}" \
   "OPT_FORTRANFLAGS,${FFLAGS:-${FFLAGS_USED}}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 # extra ones - have a dependency on the previous ones, so done after.
 _tc_activation \

--- a/ctng-osize-compilers-activation-feedstock/recipe/activate-binutils.sh
+++ b/ctng-osize-compilers-activation-feedstock/recipe/activate-binutils.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -97,7 +106,8 @@ fi
 
 _tc_activation \
   activate host @CHOST@ @CHOST@- \
-  addr2line ar as c++filt elfedit gprof ld ${GOLD_USED} nm objcopy objdump ranlib readelf size strings strip
+  addr2line ar as c++filt elfedit gprof ld ${GOLD_USED} nm objcopy objdump ranlib readelf size strings strip \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-osize-compilers-activation-feedstock/recipe/activate-g++.sh
+++ b/ctng-osize-compilers-activation-feedstock/recipe/activate-g++.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -102,7 +111,8 @@ _tc_activation \
   activate host @CHOST@ @CHOST@- \
   c++ g++ \
   "CXXFLAGS,${CXXFLAGS:-${CXXFLAGS_USED}}" \
-  "DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-${DEBUG_CXXFLAGS_USED}}"
+  "DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-${DEBUG_CXXFLAGS_USED}}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-osize-compilers-activation-feedstock/recipe/activate-gcc.sh
+++ b/ctng-osize-compilers-activation-feedstock/recipe/activate-gcc.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -139,7 +148,8 @@ _tc_activation \
   "LDFLAGS,${LDFLAGS:-${LDFLAGS_USED}}" \
   "DEBUG_CPPFLAGS,${CPPFLAGS:-@DEBUG_CPPFLAGS@}" \
   "DEBUG_CFLAGS,${DEBUG_CFLAGS:-${DEBUG_CFLAGS_USED}}" \
-  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}"
+  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-osize-compilers-activation-feedstock/recipe/activate-gfortran.sh
+++ b/ctng-osize-compilers-activation-feedstock/recipe/activate-gfortran.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -103,6 +112,7 @@ _tc_activation \
   "FORTRANFLAGS,${FORTRANFLAGS:-${FFLAGS_USED}}" \
   "DEBUG_FFLAGS,${FFLAGS:-${FFLAGS_USED} @DEBUG_FFLAGS@}" \
   "DEBUG_FORTRANFLAGS,${FORTRANFLAGS:-${FFLAGS_USED} @DEBUG_FFLAGS@}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 # extra ones - have a dependency on the previous ones, so done after.
 _tc_activation \

--- a/ctng-osize-compilers-activation-feedstock/recipe/deactivate-binutils.sh
+++ b/ctng-osize-compilers-activation-feedstock/recipe/deactivate-binutils.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -97,7 +106,8 @@ fi
 
 _tc_activation \
   deactivate host @CHOST@ @CHOST@- \
-  addr2line ar as c++filt elfedit gprof ld ${GOLD_USED} nm objcopy objdump ranlib readelf size strings strip
+  addr2line ar as c++filt elfedit gprof ld ${GOLD_USED} nm objcopy objdump ranlib readelf size strings strip \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-osize-compilers-activation-feedstock/recipe/deactivate-g++.sh
+++ b/ctng-osize-compilers-activation-feedstock/recipe/deactivate-g++.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -102,7 +111,8 @@ _tc_activation \
   deactivate host @CHOST@ @CHOST@- \
   c++ g++ \
   "CXXFLAGS,${CXXFLAGS:-${CXXFLAGS_USED}}" \
-  "DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-${DEBUG_CXXFLAGS_USED}}"
+  "DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-${DEBUG_CXXFLAGS_USED}}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-osize-compilers-activation-feedstock/recipe/deactivate-gcc.sh
+++ b/ctng-osize-compilers-activation-feedstock/recipe/deactivate-gcc.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -108,7 +117,8 @@ _tc_activation \
   "LDFLAGS,${LDFLAGS:-${LDFLAGS_USED}}" \
   "DEBUG_CPPFLAGS,${CPPFLAGS:-@DEBUG_CPPFLAGS@}" \
   "DEBUG_CFLAGS,${DEBUG_CFLAGS:-${DEBUG_CFLAGS_USED}}" \
-  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}"
+  "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"

--- a/ctng-osize-compilers-activation-feedstock/recipe/deactivate-gfortran.sh
+++ b/ctng-osize-compilers-activation-feedstock/recipe/deactivate-gfortran.sh
@@ -47,8 +47,17 @@ function _tc_activation() {
     to=""
   fi
 
+  work=("$@")
+
+  if [ "${CONDA_BUILD}" = "1" ]; then
+    CONDA_ACTIVATION_SET_HOST=1
+  fi
+  if [ "${CONDA_ACTIVATION_SET_HOST}" = "1" ]; then
+    work+=("${tc_nature},${tc_machine}")
+  fi
+
   for pass in check apply; do
-    for thing in $tc_nature,$tc_machine "$@"; do
+    for thing in "${work[@]}"; do
       case "${thing}" in
         *,*)
           newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
@@ -103,6 +112,7 @@ _tc_activation \
   "FORTRANFLAGS,${FORTRANFLAGS:-${FFLAGS_USED}}" \
   "DEBUG_FFLAGS,${FFLAGS:-${FFLAGS_USED} @DEBUG_FFLAGS@}" \
   "DEBUG_FORTRANFLAGS,${FORTRANFLAGS:-${FFLAGS_USED} @DEBUG_FFLAGS@}" \
+  "CONDA_TOOLCHAIN_HOST,@CHOST@"
 
 # extra ones - have a dependency on the previous ones, so done after.
 _tc_activation \


### PR DESCRIPTION
Define new CONDA_TOOLCHAIN_HOST variable that is set the
way HOST was previously set.

HOST is now set only when CONDA_BUILD or CONDA_ACTIVATION_SET_HOST
is set to 1

fixes #151