### PR TITLE
Added missing disable for for windows architectures for python>=3.7

### DIFF
--- a/blist-feedstock/recipe/meta.yaml
+++ b/blist-feedstock/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+  # header/preprocessor issue for VS, therefore disabled
+  skip: True  # [win and py>36]
 
 requirements:
   build:


### PR DESCRIPTION
blist build has issues for python >=3.7 on windows.  For now disabled it for unbreaking mass build