### PR TITLE
Support noarch_python jinja in cbc

### DIFF
--- a/conda_build_config-dbg.yaml
+++ b/conda_build_config-dbg.yaml
@@ -3,6 +3,8 @@ DEBUG_C:
 pin_run_as_build:
   libboost:
     max_pin: x.x.x
+noarch_python:
+  - python
 apr:
   - 1.6.3
 blas_impl:

--- a/conda_build_config-dbg_c-dbg_py.yaml
+++ b/conda_build_config-dbg_c-dbg_py.yaml
@@ -2,7 +2,7 @@ pin_run_as_build:
   libboost:
     max_pin: x.x.x
 noarch_python:
-  - False
+  - python
 
 
 DEBUG_C:

--- a/conda_build_config-osize.yaml
+++ b/conda_build_config-osize.yaml
@@ -2,7 +2,7 @@ pin_run_as_build:
   libboost:
     max_pin: x.x.x
 noarch_python:
-  - False
+  - python
 
 apr:
   - 1.6.3

--- a/conda_build_config.macos-10.10.yaml
+++ b/conda_build_config.macos-10.10.yaml
@@ -1,6 +1,8 @@
 pin_run_as_build:
   libboost:
     max_pin: x.x.x
+noarch_python:
+  - python
 
 apr:
   - 1.6.3

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -2,6 +2,8 @@
 pin_run_as_build:
   libboost:
     max_pin: x.x.x
+noarch_python:
+  - python
 apr:
   - 1.6.3
 blas_impl:


### PR DESCRIPTION
noarch_python wasn't supported in all cbcs's. Also we want to enable it to work as 'noarch', so enabled it as 'noarch: python'