### PR TITLE
Merge pull request #179 from jjhelmus/goodbye_py27

### DIFF
--- a/conda_build_config_with27.yaml
+++ b/conda_build_config_with27.yaml
@@ -15,16 +15,19 @@ bzip2:
 cairo:
   - 1.14
 c_compiler:
+  - vs2008                     # [win]
   - vs2017                     # [win]
   - vs2017                     # [win]
   - vs2017                     # [win]
 cxx_compiler:
+  - vs2008                     # [win]
   - vs2017                     # [win]
   - vs2017                     # [win]
   - vs2017                     # [win]
 fortran_compiler:
   - intel-fortran              # [win]
 fortran_compiler_version:
+  - 13.1.6                       # [win]
   - 2019.0.0                     # [win]
   - 2019.0.0                     # [win]
   - 2019.0.0                     # [win]
@@ -76,6 +79,7 @@ gstreamer:
 gst_plugins_base:
   - 1.14
 geos:
+  - 3.6.2  # [win]
   - 3.8.0  # [win]
   - 3.8.0  # [win]
   - 3.8.0
@@ -141,6 +145,7 @@ mkl:
 mpfr:
   - 4
 nodejs:
+  - 6.10  # [win]
   - 8.12  # [win]
   - 8.12  # [win]
   - 8.12
@@ -173,6 +178,7 @@ proj:
 libprotobuf:
   - 3.6.0
 python:
+  - 2.7
   - 3.6
   - 3.7
   - 3.8
@@ -198,6 +204,7 @@ target_platform:
 tk:
   - 8.6                # [not ppc64le]
 vc:
+  - 9                          # [win]
   - 14                         # [win]
   - 14                         # [win]
   - 14                         # [win]


### PR DESCRIPTION
Remove Python 2.7 from the build matrix in conda_build_config.yaml
The `conda_build_config_with27.yaml` file can be used if a build matrix
containing Python 2.7 is needed.