### PR TITLE
add Navigator tiles for cmd.exe and powershell shortcuts

### DIFF
--- a/console_shortcut-feedstock/recipe/meta.yaml
+++ b/console_shortcut-feedstock/recipe/meta.yaml
@@ -5,20 +5,17 @@ package:
 build:
   number: 4
 
-
 app:
   entry:
-    - start
-    - cmd.exe
-    - "/K"
-    - "${CONDA_ROOT_PREFIX}\\Scripts\\activate.bat"
-    - "${CONDA_PREFIX}"
+    start cmd.exe /K "${CONDA_ROOT_PREFIX}\\Scripts\\activate.bat" "${CONDA_PREFIX}"
   summary: Anaconda Powershell Prompt
   type: desk
 
 requirements:
   run:
     - python
+  run_constrained:
+    - anaconda-navigator >=1.9.8
 
 about:
   license: BSD

--- a/console_shortcut-feedstock/recipe/meta.yaml
+++ b/console_shortcut-feedstock/recipe/meta.yaml
@@ -3,7 +3,18 @@ package:
   version: 0.1.1
 
 build:
-  number: 3
+  number: 4
+
+
+app:
+  entry:
+    - start
+    - cmd.exe
+    - "/K"
+    - "${CONDA_ROOT_PREFIX}\\Scripts\\activate.bat"
+    - "${CONDA_PREFIX}"
+  summary: Anaconda Powershell Prompt
+  type: desk
 
 requirements:
   run:

--- a/powershell_shortcut-feedstock/recipe/meta.yaml
+++ b/powershell_shortcut-feedstock/recipe/meta.yaml
@@ -3,7 +3,20 @@ package:
   version: 0.0.1
 
 build:
-  number: 2
+  number: 3
+
+app:
+  entry:
+    - start
+    - powershell.exe
+    - -ExecutionPolicy
+    - ByPass
+    - -NoExit
+    - -Command
+    - |
+      & '{CONDA_ROOT_PREFIX}\\shell\\condabin\\conda-hook.ps1' ; conda activate '{CONDA_PREFIX}'
+  summary: Anaconda Powershell Prompt
+  type: desk
 
 requirements:
   run:

--- a/powershell_shortcut-feedstock/recipe/meta.yaml
+++ b/powershell_shortcut-feedstock/recipe/meta.yaml
@@ -7,20 +7,15 @@ build:
 
 app:
   entry:
-    - start
-    - powershell.exe
-    - -ExecutionPolicy
-    - ByPass
-    - -NoExit
-    - -Command
-    - |
-      & '{CONDA_ROOT_PREFIX}\\shell\\condabin\\conda-hook.ps1' ; conda activate '{CONDA_PREFIX}'
+    start powershell.exe -ExecutionPolicy ByPass -NoExit -Command  "& '{CONDA_ROOT_PREFIX}\\shell\\condabin\\conda-hook.ps1' ; conda activate '{CONDA_PREFIX}'"
   summary: Anaconda Powershell Prompt
   type: desk
 
 requirements:
   run:
     - python
+  run_constrained:
+    - anaconda-navigator >=1.9.8
 
 about:
   license: BSD


### PR DESCRIPTION
These require https://github.com/ContinuumIO/navigator/pull/1759 to work properly.  Older versions of navigator should be able to install these, but will almost certainly barf (but hopefully not crash) if users try to run these.