### PR TITLE
vs2008+vs2015: make sure to append on a newline in activate.bat

### DIFF
--- a/vs2008/install_activate.bat
+++ b/vs2008/install_activate.bat
@@ -4,6 +4,7 @@ set VER=9
 mkdir "%PREFIX%\etc\conda\activate.d"
 COPY "%RECIPE_DIR%\activate.bat" "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 
+echo.>> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 echo IF "%%CMAKE_GENERATOR%%" == "" ( >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 
 IF "%cross_compiler_target_platform%" == "win-64" (

--- a/vs2008/meta.yaml
+++ b/vs2008/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 build:
   skip: True  [not win]
-  number: 5
+  number: 6
 
 outputs:
   - name: vs{{ vsyear }}_{{ cross_compiler_target_platform }}

--- a/vs2015/install_activate.bat
+++ b/vs2015/install_activate.bat
@@ -4,6 +4,7 @@ set VER=14
 mkdir "%PREFIX%\etc\conda\activate.d"
 COPY "%RECIPE_DIR%\activate.bat" "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 
+echo.>> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 echo IF "%%CMAKE_GENERATOR%%" == "" ( >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 
 IF "%cross_compiler_target_platform%" == "win-64" (

--- a/vs2015/meta.yaml
+++ b/vs2015/meta.yaml
@@ -9,7 +9,7 @@ package:
   version: {{ fullver }}
 
 build:
-  number: 10
+  number: 12
   skip: True  [not win]
 
 outputs:


### PR DESCRIPTION
cc @isuruf, @pgunn, @katietz

Builds `vs2015_win-64=14.0.25420=h55c1224_10` and `vs2015_win-64=14.0.25420=h55c1224_11`from https://github.com/AnacondaRecipes/aggregate/pull/153 broke the feature that was intended to be added by https://github.com/AnacondaRecipes/aggregate/pull/138 due to a missing new line at the end of `activate.bat`, resulting in broken `:EndIF "%%CMAKE_GENERATOR%%" == "" (` line.

- Can we get a new build of `vs2015`?
- Also, the current build of `vs2008` does not show this error, but it also does not incorporate  https://github.com/AnacondaRecipes/aggregate/pull/138
  => Can we also get a new build of `vs2008` then?

Technically the recipe doesn't need to be modified, but the changes from this PR would make sure we don't concatenate those lines in any case.

<details>

Although `activate.bat` from
https://github.com/AnacondaRecipes/aggregate/pull/153/files#diff-97f79d38f2d800f3d24ec2795ff9df99R79
ends with a new line, the line from
https://github.com/AnacondaRecipes/aggregate/pull/138/files#diff-9b116031ffcc1c3d45f99796323c3223R7
got appended to the last non-empty line:
```
> curl -sL https://repo.anaconda.com/pkgs/main/win-64/vs2015_win-64-14.0.25420-h55c1224_11.tar.bz2 | tar -xjO info/recipe/parent/activate.bat etc/conda/activate.d/vs2015_compiler_vars.bat | grep :End\\\|%CMAKE_GENERATOR | hexdump -C
00000000  3a 45 6e 64 40 65 63 68  6f 20 6f 6e 0d 0a 3a 45  |:End@echo on..:E|
00000010  6e 64 49 46 20 22 25 43  4d 41 4b 45 5f 47 45 4e  |ndIF "%CMAKE_GEN|
00000020  45 52 41 54 4f 52 25 22  20 3d 3d 20 22 22 20 28  |ERATOR%" == "" (|
00000030  20 0d 0a                                          | ..|
00000033
```
This shows the erroneous `:EndIF ...` line as well as that `activate.bat` ends with `3a 45 6e 64` with no new line. Probably something went wrong on checkout/transfer to the build system...
</details>