### PR TITLE
Fix pykerberos dependency issue with krb5

### DIFF
--- a/pykerberos-feedstock/recipe/meta.yaml
+++ b/pykerberos-feedstock/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     - 0001-Implement-mempcpy-via-memcpy.patch
 
 build:
-  number: 2
+  number: 3
   detect_binary_files_with_prefix: False
   script: python setup.py install --single-version-externally-managed --root=/
   # Use winkerberos on Windows
@@ -20,9 +20,12 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - patch  # [not win]
   host:
     - python
+    - pip
     - setuptools
+    - wheel
     - krb5
   run:
     - python
@@ -31,10 +34,15 @@ requirements:
 test:
   imports:
     - kerberos
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/02strich/pykerberos
-  license: Apache
+  license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   summary: high-level interface to Kerberos
   description: |
@@ -42,5 +50,6 @@ about:
     avoid having to build a module that wraps the entire Kerberos.framework
     and instead offer a limited set of functions that do what is needed for
     client/server Kerberos authentication.
+  dev_url: https://github.com/02strich/pykerberos
   doc_url: https://pypi.python.org/pypi/kerberos
   doc_source_url: https://github.com/apple/ccs-pykerberos/blob/master/README.rst


### PR DESCRIPTION
I create a build of `pykerberos ` that supports krb5>=1.19.1


Category:  other | subcategory:   | pkg_type:  python
Popularity:  121908 downloads -  pykerberos  1.2.1  High-level interface to Kerberos
  license: Apache
Release date:  Feb 27, 2020
Bug Tracker: new open issues https://github.com/02strich/pykerberos/issues
Github releases:  https://github.com/02strich/pykerberos/releases
License file:  https://github.com/02strich/pykerberos/blob/master/LICENSE
Upstream Changelog: https://github.com/02strich/pykerberos/blob/master/CHANGELOG.txt
Upstream setup.py:  https://github.com/02strich/pykerberos/blob/v1.2.1/setup.py

The package pykerberos is mentioned inside the packages:
airflow | requests-kerberos |

Actions:
1. Bump build number to `3`
2. Add `patch ` to the requirements/build section
3. Add missing packages to the host section: `pip`, `wheel`
4. Add `pip check` to the test/commands section
5. Update license and add license_family
6. Add dev_url

Result:
- all-succeeded
