### PR TITLE
Add console_shortcut 0.1.1 on aarch64

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_check: false

--- a/console_shortcut-feedstock/recipe/meta.yaml
+++ b/console_shortcut-feedstock/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 0.1.1
 
 build:
-  number: 4
+  number: 5
 
 app:
   entry:


### PR DESCRIPTION
Bump build number  to `5`