### PR TITLE
Update proj pinning for python 3.10

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -203,8 +203,9 @@ pixman:
 proj4:
   - 5.2.0
 proj:
-  - 6.2.1  # [not (osx and arm64)]
-  - 7.2.0  # [osx and arm64]
+  - 6.2.1  # [py<3.10 and not (osx and arm64)]
+  - 7.2.0  # [py<3.10 and osx and arm64]
+  - 8.2.1  # [py>=3.10]
 libprotobuf:
   - 3.11.2    # [not (s390x or aarch64 or (osx and arm64))]
   - 3.14.0    # [s390x or aarch64]


### PR DESCRIPTION
For Python 3.10, only proj v8.2.1 is built, so update `conda_build_config.yaml` pinning to use it.