### PR TITLE
nsis-feedstock: add AccessControl plug-in.

### DIFF
--- a/nsis-feedstock/recipe/bld.bat
+++ b/nsis-feedstock/recipe/bld.bat
@@ -1,4 +1,5 @@
 robocopy nsis-zip "%PREFIX%"\NSIS /S
 robocopy "%RECIPE_DIR%"\NSIS "%PREFIX%"\NSIS /S
+robocopy access-control\Plugins\i386-unicode "%PREFIX%"\NSIS\Plugins\x86-unicode /S
 :: Checking the ErrorLevel from robocopy is pointless.
 exit /b 0

--- a/nsis-feedstock/recipe/meta.yaml
+++ b/nsis-feedstock/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  - url: http://sourceforge.net/projects/nsis/files/NSIS%20{{ version.split(".")[0] }}/{{ version }}/nsis-{{ version }}.zip
+  - url: https://sourceforge.net/projects/nsis/files/NSIS%20{{ version.split(".")[0] }}/{{ version }}/nsis-{{ version }}.zip
     sha256: daa17556c8690a34fb13af25c87ced89c79a36a935bf6126253a9d9a5226367c
     folder: nsis-zip
   # AccessControl does not provide historical versions as far as I can tell..
@@ -19,7 +19,7 @@ build:
   skip: True  # [unix]
 
 about:
-  home: http://nsis.sourceforge.net/Main_Page
+  home: https://nsis.sourceforge.io/Main_Page
   license: Common public License Version 1.0, zlib
   license_file: nsis-zip/COPYING
   license_family: Other
@@ -28,8 +28,8 @@ about:
     NSIS (Nullsoft Scriptable Install System) is designed to be as small and
     flexible as possible and is therefore very suitable for internet
     distribution.
-  doc_url: http://nsis.sourceforge.net/Docs/
-  doc_source_url: http://nsis.sourceforge.net/Main_Page
+  doc_url: https://nsis.sourceforge.io/Docs/
+  doc_source_url: https://nsis.sourceforge.io/Main_Page
   dev_url: https://github.com/NSIS-Dev
 
 extra:

--- a/nsis-feedstock/recipe/meta.yaml
+++ b/nsis-feedstock/recipe/meta.yaml
@@ -8,9 +8,14 @@ source:
   - url: http://sourceforge.net/projects/nsis/files/NSIS%20{{ version.split(".")[0] }}/{{ version }}/nsis-{{ version }}.zip
     sha256: daa17556c8690a34fb13af25c87ced89c79a36a935bf6126253a9d9a5226367c
     folder: nsis-zip
+  # AccessControl does not provide historical versions as far as I can tell..
+  # this is for version v1.0.8.3 - 24th February 2021
+  - url: https://nsis.sourceforge.io/mediawiki/images/4/4a/AccessControl.zip
+    sha256: 9aa60f9c5c023fda2808af216514d8913d2673bc522d944ee771da032a1bdc10
+    folder: access-control
 
 build:
-  number: 8
+  number: 9
   skip: True  # [unix]
 
 about:


### PR DESCRIPTION
Adding [AccessControl](https://nsis.sourceforge.io/AccessControl_plug-in) to our `nsis` package.