### PR TITLE
pin pixman to 0.40 for all archs

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -198,8 +198,7 @@ perl:
   - 5.26    # [not (osx and arm64)]
   - 5.34    # [osx and arm64]
 pixman:
-  - 0.30      # [not (s390x or aarch64 or (osx and arm64))]
-  - 0.40      # [s390x or aarch64 or (osx and arm64)]
+  - 0.40
 proj4:
   - 5.2.0
 proj:


### PR DESCRIPTION
pixman 0.30 is not available on any arch on default. 
Some have 0.34 or 0.38, and all have 0.40.

This pins pixman to 0.40 for upcoming builds. (Need for cairo update)
