### PR TITLE
python "3.10" in quotes

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -212,7 +212,7 @@ python:
   - 3.7      # [not arm64]
   - 3.8
   - 3.9
-  - 3.10
+  - "3.10"
 python_implementation:
   - cpython
 python_impl:


### PR DESCRIPTION
Avoid 
```
>>> cbc['python']
[3.7, 3.8, 3.9, 3.1]
```