### PR TITLE
cairo 1.16 harfbuzz 4.3.0 libgd 2.3.3

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -15,8 +15,7 @@ boost_cpp:
 bzip2:
   - 1.0
 cairo:
-  - 1.14                       # [not (s390x or aarch64 or (osx and arm64))]
-  - 1.16                       # [s390x or aarch64 or (osx and arm64)]
+  - 1.16
 c_compiler:
   - gcc                        # [linux and aarch64]
   - clang                      # [osx]
@@ -113,8 +112,7 @@ gmp:
 gnu:
   - 2.12.2
 harfbuzz:
-  - 2.4  # [not ((osx and arm64) or (linux and aarch64))]
-  - 2.8  # [(osx and arm64) or (linux and aarch64)]
+  - 4.3.0
 hdf4:
   - 4.2
 hdf5:
@@ -136,7 +134,7 @@ libffi:
   # Patches need to be rebased
   - 3.4  # [win]
 libgd:
-  - 2.2.5
+  - 2.3.3
 libgdal:
   - 3.0
 libgsasl:


### PR DESCRIPTION
Jira: https://anaconda.atlassian.net/browse/DSNC-4929

Building graphviz on all platforms requires cairo 1.16 on all platform.
The update of cairo induce a rebuild of harfbuzz, which we can update and pin to 4.3.0.
Finally graphviz also depends on libgd, which was missing on some platform. We can update libgd and pin it to 2.3.3.

This involves rebuilding the following packages in order: