### PR TITLE
Upgrade ripgrep to 13.0.0

### DIFF
--- a/ripgrep-feedstock/LICENSE-MIT
+++ b/ripgrep-feedstock/LICENSE-MIT
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Andrew Gallant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/ripgrep-feedstock/recipe/meta.yaml
+++ b/ripgrep-feedstock/recipe/meta.yaml
@@ -32,7 +32,9 @@ test:
 
 about:
   home: https://github.com/BurntSushi/ripgrep
+  dev_url: https://github.com/BurntSushi/ripgrep
+  doc_url: https://github.com/BurntSushi/ripgrep
   summary: ripgrep is a line-oriented search tool that recursively searches the current directory for a regex pattern.
-  license: MIT
+  license: MIT AND Unlicense
   license_file: 
     - LICENSE-MIT

--- a/ripgrep-feedstock/recipe/meta.yaml
+++ b/ripgrep-feedstock/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '12.1.1' %}
+{% set version = '13.0.0' %}
 {% set name = 'ripgrep' %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/BurntSushi/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 2513338d61a5c12c8fea18a0387b3e0651079ef9b31f306050b1f0aaa926271e
+  sha256: 0fb17aaf285b3eee8ddab17b833af1e190d73de317ff9648751ab0660d763ed2
 
 build:
   script:
@@ -18,10 +18,19 @@ build:
     - mkdir %PREFIX%\Library\mingw-w64\bin  # [win]
     - cp target/release/rg $PREFIX/bin/rg  # [not win]
     - copy target\release\rg.exe %PREFIX%\Library\mingw-w64\bin\rg.exe  # [win]
-  missing_dso_whitelist:
-    - /usr/lib/libresolv.9.dylib
 
 requirements:
   build:
     - {{ compiler('rust') }}  # [not win]
     - {{ compiler('rust-gnu') }}  # [win]
+
+test:
+  commands:
+    - rg --version
+
+about:
+  home: https://github.com/BurntSushi/ripgrep
+  summary: ripgrep is a line-oriented search tool that recursively searches the current directory for a regex pattern.
+  license: MIT
+  license_file: 
+    - LICENSE-MIT

--- a/ripgrep-feedstock/recipe/meta.yaml
+++ b/ripgrep-feedstock/recipe/meta.yaml
@@ -36,5 +36,6 @@ about:
   doc_url: https://github.com/BurntSushi/ripgrep
   summary: ripgrep is a line-oriented search tool that recursively searches the current directory for a regex pattern.
   license: MIT AND Unlicense
+  license_family: Other
   license_file: 
     - LICENSE-MIT

--- a/ripgrep-feedstock/recipe/meta.yaml
+++ b/ripgrep-feedstock/recipe/meta.yaml
@@ -18,6 +18,8 @@ build:
     - mkdir %PREFIX%\Library\mingw-w64\bin  # [win]
     - cp target/release/rg $PREFIX/bin/rg  # [not win]
     - copy target\release\rg.exe %PREFIX%\Library\mingw-w64\bin\rg.exe  # [win]
+  missing_dso_whitelist:
+    - $RPATH/ld64.so.1  # [s390x]
 
 requirements:
   build:


### PR DESCRIPTION
The `missing_dso_whitelist` functionality for `libresolve` is no longer needed as that compiler bug was fixed a while ago.
https://github.com/rust-lang/rust/issues/46797. But `ld64` has to be added for the `s390x` architecture, as that is not exported by the library.

Added a simple test to verify that `rg` is invoked correctly, along with a brief summary.

Concourse: https://concourse.build.corp.continuum.io/teams/main/pipelines/stiwari_ripgrep