### PR TITLE
Conda-Token update to 0.4.0

### DIFF
--- a/conda-token-feedstock/recipe/meta.yaml
+++ b/conda-token-feedstock/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-token" %}
-{% set version = "0.3.0" %}
+{% set version = "0.4.0" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
`Conda-token` version bump to `0.4.0`. 