### PR TITLE
Update CBC to point to new Windows Fortran compiler 2022.1.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -55,7 +55,7 @@ cxx_compiler_version:      # [linux or osx]
   - 11.2.0                 # [linux]
   - 12                     # [osx]
 fortran_compiler_version:
-  - 2019.0.0                     # [win]
+  - 2022.1.0                     # [win]
   - 11.2.0                       # [osx or linux]
 clang_variant:
   - clang

--- a/intel-fortran/conda_build_config.yaml
+++ b/intel-fortran/conda_build_config.yaml
@@ -11,6 +11,3 @@ zip_keys:
   - compiler_version
   - intel_fortran_version
 
-# necessary to build until updated on main cbc
-fortran_compiler_version:       # [win]
-  - 2022.1.0                    # [win]


### PR DESCRIPTION
Updates to conda_build_config.yaml to use new fortran compiler on windows in prefect.

Windows builds that use fortran will no longer build on concourse after this is merged. They can still be build by changing the `fortran_compiler_version` parameter back to an old version in a cbc in the recipe.