### PR TITLE
Relax expat pinning

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -65,9 +65,7 @@ cyrus_sasl:
 dbus:
   - 1
 expat:
-  - 2.2  # [not ((osx and arm64) or (linux and aarch64))]
-  - 2.3  # [linux and aarch64]
-  - 2.4  # [osx and arm64]
+  - 2
 fontconfig:
   - 2.13
 freetype:


### PR DESCRIPTION
expat has a run export based on major version.
expat change log shows no breaking change between minor versions.

See current dependencies on expat:
https://metayaml-conda.fly.dev/metayaml/reverse_dependencies?name=expat
Expat changelog:
https://github.com/libexpat/libexpat/blob/master/expat/Changes

Jira:
- https://anaconda.atlassian.net/browse/PKG-41