### PR TITLE
Update compiler version in intel-fortran recipe

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,5 @@
 aggregate_check: false
+
+build_parameters:
+  - "--suppress-variables"
+  - "--skip-existing"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,1 @@
 aggregate_check: false
-
-build_parameters:
-  - "--suppress-variables"
-  - "--skip-existing"

--- a/intel-fortran/conda_build_config.yaml
+++ b/intel-fortran/conda_build_config.yaml
@@ -10,3 +10,7 @@ intel_fortran_version:
 zip_keys:
   - compiler_version
   - intel_fortran_version
+
+# necessary to build until updated on main cbc
+fortran_compiler_version:       # [win]
+  - 2022.1.0                    # [win]

--- a/intel-fortran/meta.yaml
+++ b/intel-fortran/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 build:
   skip: True  # [not win]
-  number: 1
+  number: 2
 
 outputs:
   - name: intel-fortran_{{ cross_compiler_target_platform }}


### PR DESCRIPTION
This parameter needs to be manually overridden before it is added to the main cbc.