### PR TITLE
remove `ppc64le` selector from tk

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -214,7 +214,7 @@ target_platform:
   - win-64                     # [win]
   # - win-32                     # [win]
 tk:
-  - 8.6                # [not ppc64le]
+  - 8.6
 vc:
   - 14                         # [win]
 zlib:


### PR DESCRIPTION
building python and encountering issues with building ppc64le, i noticed we pin tk for everything except ppc64le.

currently, the pinned version is the only version available for ppc64le, so there is not yet any inconsistency as far as i can tell, but i thought it might be a good idea to pin this to minimize any potential issues/feature drift between platforms in the future.