### PR TITLE
Revert `mkl` to version 2021

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -148,7 +148,7 @@ MACOSX_DEPLOYMENT_TARGET:
   - 10.9  # [osx and x86_64]
   - 11.1  # [osx and arm64]
 mkl:
-  - 2022.*
+  - 2021.*
 mpfr:
   - 4
 # we build for an old version of numpy for forward compatibility


### PR DESCRIPTION
Revert `MKL` to version 2021 in the `conda_build_config.yaml` file.
This is done in order to prevent breaking changes to be introduced in the packages in the distribution. 
Once the new version of `MKL` is stable, then the `conda_build_config.yaml` file will be updated with the latest version. 