### PR TITLE
psycopg2-feedstock: fix default branch name

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1498,7 +1498,7 @@
 [submodule "psycopg2-feedstock"]
 	path = psycopg2-feedstock
 	url = ../psycopg2-feedstock
-	branch = master
+	branch = main
 [submodule "pyasn1-feedstock"]
 	path = pyasn1-feedstock
 	url = ../pyasn1-feedstock


### PR DESCRIPTION
Changed default branch name in .gitmodules for psycopg2-feedstock from master to main