### PR TITLE
pycosat main

### DIFF
--- a/conda-repo-cli-feedstock/recipe/meta.yaml
+++ b/conda-repo-cli-feedstock/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/aecobra/conda_repo_cli.git
+  git_url: ssh://git@github.com/aecobra/conda_repo_cli.git
   git_rev: {{ version }}
 
 build:
@@ -16,6 +16,8 @@ build:
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
+  build:
+    - git
   host:
     - python
     - pip
@@ -43,3 +45,4 @@ about:
   license_family: BSD
   license_file: LICENSE.md
   summary: Anaconda Repository command line client library
+


### PR DESCRIPTION
CI complains that pycosat-feedstock's branch was renamed to main