### PR TITLE
Update Magma to 2.7.0

### DIFF
--- a/magma-feedstock/recipe/bld.bat
+++ b/magma-feedstock/recipe/bld.bat
@@ -1,19 +1,20 @@
 md build
-cd build
 if errorlevel 1 exit /b 1
 
-cmake %SRC_DIR%^
+cmake ^
+  -S . ^
+  -B build
   -G "Ninja" ^
   -DUSE_FORTRAN=OFF ^
   -DMAGMA_ENABLE_CUDA=ON ^
   -DCMAKE_BUILD_TYPE=Release ^
   -DGPU_TARGET="Fermi Kepler Maxwell Pascal Volta Turing Ampere" ^
-  -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+  -DMAGMA_WITH_MKL ^
   -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
   -DCUDA_NVCC_FLAGS="--use-local-env" ^
 if errorlevel 1 exit /b 1
 
-cmake --build . ^
+cmake --build build ^
       --config Release ^
       --parallel %CPU_COUNT% ^
       --target magma magma_sparse ^

--- a/magma-feedstock/recipe/bld.bat
+++ b/magma-feedstock/recipe/bld.bat
@@ -3,7 +3,7 @@ if errorlevel 1 exit /b 1
 
 cmake ^
   -S . ^
-  -B build
+  -B build ^
   -G "Ninja" ^
   -DUSE_FORTRAN=OFF ^
   -DMAGMA_ENABLE_CUDA=ON ^

--- a/magma-feedstock/recipe/bld.bat
+++ b/magma-feedstock/recipe/bld.bat
@@ -1,12 +1,23 @@
-cmake ^
-  -H. ^
-  -Bbuild ^
-  -G"Ninja" ^
+md build
+cd build
+if errorlevel 1 exit /b 1
+
+cmake %SRC_DIR%^
+  -G "Ninja" ^
   -DUSE_FORTRAN=OFF ^
+  -DMAGMA_ENABLE_CUDA=ON ^
   -DCMAKE_BUILD_TYPE=Release ^
+  -DGPU_TARGET="Fermi Kepler Maxwell Pascal Volta Turing Ampere" ^
   -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
-  -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%
+  -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+  -DCUDA_NVCC_FLAGS="--use-local-env" ^
+if errorlevel 1 exit /b 1
 
-cmake --build build
+cmake --build . ^
+      --config Release ^
+      --parallel %CPU_COUNT% ^
+      --target magma magma_sparse ^
+      --verbose
+if errorlevel 1 exit /b 1
 
-cmake --build build -- install
+cmake --install .

--- a/magma-feedstock/recipe/build.sh
+++ b/magma-feedstock/recipe/build.sh
@@ -6,7 +6,7 @@ export PATH=$PREFIX/bin:/usr/local/cuda-${cudatoolkit}/bin:$PATH
 
 mkdir build
 cd build
-cmake .. -DUSE_FORTRAN=OFF -DGPU_TARGET="Fermi Kepler Maxwell Pascal Volta Turing Ampere" -DMAGMA_ENABLE_CUDA=ON -DCMAKE_INSTALL_PREFIX=$PREFIX
+cmake .. -DUSE_FORTRAN=OFF -DGPU_TARGET="Fermi Kepler Maxwell Pascal Volta Turing Ampere" -DMAGMA_ENABLE_CUDA=ON -DMAGMA_WITH_MKL -DCMAKE_INSTALL_PREFIX=$PREFIX
 make -j${CPU_COUNT} ${VERBOSE_AT}
 make install
 cd ..

--- a/magma-feedstock/recipe/build.sh
+++ b/magma-feedstock/recipe/build.sh
@@ -6,7 +6,7 @@ export PATH=$PREFIX/bin:$PATH
 
 CUDA__VERSION=$(nvcc --version|tail -n1|cut -f5 -d" "|cut -f1 -d",")
 if [ "$CUDA__VERSION" != "${cudatoolkit}" ]; then
-    echo "CUDA Version is not ${cudatoolkit} CUDA Version found: $CUDA__VERSION"
+    echo "CUDA version is not ${cudatoolkit}; CUDA version found: $CUDA__VERSION"
     exit 1
 fi
 

--- a/magma-feedstock/recipe/build.sh
+++ b/magma-feedstock/recipe/build.sh
@@ -2,17 +2,11 @@
 
 export CMAKE_LIBRARY_PATH=$PREFIX/lib:$PREFIX/include:$CMAKE_LIBRARY_PATH
 export CMAKE_PREFIX_PATH=$PREFIX
-export PATH=$PREFIX/bin:$PATH
-
-CUDA__VERSION=$(nvcc --version|tail -n1|cut -f5 -d" "|cut -f1 -d",")
-if [ "$CUDA__VERSION" != "${cudatoolkit}" ]; then
-    echo "CUDA version is not ${cudatoolkit}; CUDA version found: $CUDA__VERSION"
-    exit 1
-fi
+export PATH=$PREFIX/bin:/usr/local/cuda-${cudatoolkit}/bin:$PATH
 
 mkdir build
 cd build
-cmake .. -DUSE_FORTRAN=OFF -DGPU_TARGET="All" -DCMAKE_INSTALL_PREFIX=$PREFIX
+cmake .. -DUSE_FORTRAN=OFF -DGPU_TARGET="Fermi Kepler Maxwell Pascal Volta Turing Ampere" -DMAGMA_ENABLE_CUDA=ON -DCMAKE_INSTALL_PREFIX=$PREFIX
 make -j${CPU_COUNT} ${VERBOSE_AT}
 make install
 cd ..

--- a/magma-feedstock/recipe/conda_build_config.yaml
+++ b/magma-feedstock/recipe/conda_build_config.yaml
@@ -1,6 +1,10 @@
-cxx_compiler_version:
-  - 9.3.0
-c_compiler_version:
-  - 9.3.0
+cxx_compiler:           # [win]
+  - vs2019              # [win]
+c_compiler:             # [win]
+  - vs2019              # [win]
+cxx_compiler_version:   # [linux64]
+  - 9.3.0               # [linux64]
+c_compiler_version:     # [linux64]
+  - 9.3.0               # [linux64]
 cudatoolkit:
   - 11.3

--- a/magma-feedstock/recipe/conda_build_config.yaml
+++ b/magma-feedstock/recipe/conda_build_config.yaml
@@ -1,6 +1,6 @@
-c_compiler_version:
-  - 7.3
 cxx_compiler_version:
-  - 7.3
+  - 9.3.0
+c_compiler_version:
+  - 9.3.0
 cudatoolkit:
   - 11.3

--- a/magma-feedstock/recipe/conda_build_config.yaml
+++ b/magma-feedstock/recipe/conda_build_config.yaml
@@ -1,8 +1,6 @@
-# cuda 9.0, 5.4
-# cuda 10.0, 7.3
 c_compiler_version:
   - 7.3
 cxx_compiler_version:
   - 7.3
 cudatoolkit:
-  - 10.0
+  - 11.3

--- a/magma-feedstock/recipe/meta.yaml
+++ b/magma-feedstock/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [osx]
+  skip: True  # [osx or win32]
 
 requirements:
   build:

--- a/magma-feedstock/recipe/meta.yaml
+++ b/magma-feedstock/recipe/meta.yaml
@@ -12,19 +12,17 @@ source:
 
 build:
   number: 0
-  skip: True  # [win and vc<14]
-  skip: True  # [win32]
+  skip: True  # [win or osx]
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake
-    - ninja       # [win]
-    - patch       # [not win]
-    - m2-patch    # [win]
+    - patch
   host:
     - cudatoolkit {{ cudatoolkit }}*
+    - libopenblas
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 

--- a/magma-feedstock/recipe/meta.yaml
+++ b/magma-feedstock/recipe/meta.yaml
@@ -2,15 +2,12 @@
 # TODO: examine if it is possible to link DSO dynamically
 package:
   name: magma
-  version: 2.5.0
+  version: 2.7.0
 
 source:
-   url: http://icl.cs.utk.edu/projectsfiles/magma/downloads/magma-2.5.0.tar.gz
-   sha256: 4fd45c7e46bd9d9124253e7838bbfb9e6003c64c2c67ffcff02e6c36d2bcfa33
+   url: http://icl.cs.utk.edu/projectsfiles/magma/downloads/magma-2.7.0.tar.gz
+   sha256: fda1cbc4607e77cacd8feb1c0f633c5826ba200a018f647f1c5436975b39fd18
    patches:
-    - cmakelists_cuda90.patch   # [cudatoolkit=='9.0']
-    - cmakelists_cuda100.patch  # [cudatoolkit=='10.0']
-    - xhsgetrf_gpu.patch        # [cudatoolkit=='9.0']
     - thread_queue.patch
 
 build:
@@ -23,7 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake
-    - ninja  # [win]
+    - ninja       # [win]
     - patch       # [not win]
     - m2-patch    # [win]
   host:
@@ -31,9 +28,22 @@ requirements:
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 
+test:
+  commands:
+      - test -f $PREFIX/include/magma.h                             # [unix]
+      - test -f $PREFIX/lib/libmagma${SHLIB_EXT}                    # [unix]
+      - test -f $PREFIX/lib/libmagma_sparse${SHLIB_EXT}             # [unix]
+      - if not exist %LIBRARY_PREFIX%\include\magma.h exit 1        # [win]
+      - if not exist %LIBRARY_PREFIX%\lib\magma.lib exit 1          # [win]
+      - if not exist %LIBRARY_PREFIX%\bin\magma.dll exit 1          # [win]
+      - if not exist %LIBRARY_PREFIX%\lib\magma_sparse.lib exit 1   # [win]
+      - if not exist %LIBRARY_PREFIX%\bin\magma_sparse.dll exit 1   # [win]
+
 about:
-  home: http://icl.cs.utk.edu/magma/software/index.html
+  home: https://icl.utk.edu/magma/index.html
   license: BSD 3-Clause
   license_family: BSD
   license_file: COPYRIGHT
   summary: Matrix Algebra on GPU and Multicore Architectures
+  doc_url: https://icl.utk.edu/projectsfiles/magma/doxygen/
+  dev_url: https://bitbucket.org/icl/magma/

--- a/magma-feedstock/recipe/meta.yaml
+++ b/magma-feedstock/recipe/meta.yaml
@@ -28,14 +28,9 @@ requirements:
 
 test:
   commands:
-      - test -f $PREFIX/include/magma.h                             # [unix]
-      - test -f $PREFIX/lib/libmagma${SHLIB_EXT}                    # [unix]
-      - test -f $PREFIX/lib/libmagma_sparse${SHLIB_EXT}             # [unix]
-      - if not exist %LIBRARY_PREFIX%\include\magma.h exit 1        # [win]
-      - if not exist %LIBRARY_PREFIX%\lib\magma.lib exit 1          # [win]
-      - if not exist %LIBRARY_PREFIX%\bin\magma.dll exit 1          # [win]
-      - if not exist %LIBRARY_PREFIX%\lib\magma_sparse.lib exit 1   # [win]
-      - if not exist %LIBRARY_PREFIX%\bin\magma_sparse.dll exit 1   # [win]
+      - test -f $PREFIX/include/magma.h
+      - test -f $PREFIX/lib/libmagma${SHLIB_EXT}
+      - test -f $PREFIX/lib/libmagma_sparse${SHLIB_EXT}
 
 about:
   home: https://icl.utk.edu/magma/index.html

--- a/magma-feedstock/recipe/meta.yaml
+++ b/magma-feedstock/recipe/meta.yaml
@@ -12,25 +12,32 @@ source:
 
 build:
   number: 0
-  skip: True  # [win or osx]
+  skip: True  # [osx]
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake
-    - patch
+    - ninja       # [win]
+    - m2-patch    # [win]
+    - patch       # [not win]
   host:
     - cudatoolkit {{ cudatoolkit }}*
-    - libopenblas
+    - mkl
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 
 test:
   commands:
-      - test -f $PREFIX/include/magma.h
-      - test -f $PREFIX/lib/libmagma${SHLIB_EXT}
-      - test -f $PREFIX/lib/libmagma_sparse${SHLIB_EXT}
+    - test -f $PREFIX/include/magma.h                             # [unix]
+    - test -f $PREFIX/lib/libmagma${SHLIB_EXT}                    # [unix]
+    - test -f $PREFIX/lib/libmagma_sparse${SHLIB_EXT}             # [unix]
+    - if not exist %LIBRARY_PREFIX%\include\magma.h exit 1        # [win]
+    - if not exist %LIBRARY_PREFIX%\lib\magma.lib exit 1          # [win]
+    - if not exist %LIBRARY_PREFIX%\bin\magma.dll exit 1          # [win]
+    - if not exist %LIBRARY_PREFIX%\lib\magma_sparse.lib exit 1   # [win]
+    - if not exist %LIBRARY_PREFIX%\bin\magma_sparse.dll exit 1   # [win]
 
 about:
   home: https://icl.utk.edu/magma/index.html


### PR DESCRIPTION
Updating `magma` to `2.7.0`.

We actually don't really need to upgrade it to the latest version, but the version we have currently is built against an older version of `cudatoolkit`. This makes it impossible to use `magma` in newer packages like `pytorch`, because they usually require a newer version of CUDA.

Note that this recipe **cannot** be built on Prefect/Concourse, and must be built out manually due to the CUDA requirement. Additionally, while it _can_ be built on Windows, due to CMake problems with CUDA tooling we unfortunately can't do so on our builders.