### PR TITLE
pin numpy to 1.21 for python 3.8 and 3.9

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -151,12 +151,10 @@ mpfr:
   - 4
 # we build for an old version of numpy for forward compatibility
 numpy:
-  # python 3.8-3.9
-  - 1.16    # [not (osx and arm64)]
-  - 1.16    # [not (osx and arm64)]
-  # python 3.8-3.9
-  - 1.19    # [osx and arm64]
-  - 1.19    # [osx and arm64]
+  # python 3.8
+  - 1.21
+  # python 3.9
+  - 1.21
   # python 3.10
   - 1.21
   # python 3.11


### PR DESCRIPTION
Changes:
- pin numpy to 1.21 for python 3.8 and 3.9


Based on analysis of repodata.json, numpy pin can safely be updated to 1.21 for python 3.8 and python 3.9.

The only package which requires a rebuild is pytables 3.8.0, which appears to have incorrect run dependency on numpy, on the exact version of the cbc.

All other packages have an upper bound which allow at least 1.21.

See per architecture reports and analysis script: https://anaconda.atlassian.net/browse/PKG-739