### PR TITLE
Add libxkbfile and libxkbfile-devel CDT for linux-64

### DIFF
--- a/cdt_cos6_x86_64/libxkbfile-cos6-x86_64/build.sh
+++ b/cdt_cos6_x86_64/libxkbfile-cos6-x86_64/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+mkdir -p ${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot
+mkdir -p ${PREFIX}/x86_64-conda-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd ${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .
+popd
+pushd ${PREFIX}/x86_64-conda-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .
+popd
+

--- a/cdt_cos6_x86_64/libxkbfile-cos6-x86_64/meta.yaml
+++ b/cdt_cos6_x86_64/libxkbfile-cos6-x86_64/meta.yaml
@@ -1,0 +1,25 @@
+package:
+  name: libxkbfile-cos6-x86_64
+  version: 1.0.6
+
+source:
+  - url: https://vault.centos.org/centos/6.10/os/x86_64/Packages/libxkbfile-1.0.6-1.1.el6.x86_64.rpm
+    sha256: 0c8c125d6b4c0db5368f439c045073cb2cc55e6207bdff4d143d5bb48ae873fb
+    no_hoist: true
+    folder: binary
+  - url: https://vault.centos.org/6.10/os/Source/SPackages/libxkbfile-1.0.6-1.1.el6.src.rpm
+    sha256: 555d3e4920aa3ff5eab1a82b360d601719628d79875288f76b519b72241b543a
+    folder: source
+
+build:
+  number: 1
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+about:
+  home: https://xorg.freedesktop.org/
+  license: MIT
+  license_family: MIT
+  summary: "(CDT) X.Org X11 libxkbfile runtime library"
+  description: libxkbfile is used by the X servers and utilities to parse the XKB configuration data files.

--- a/cdt_cos6_x86_64/libxkbfile-devel-cos6-x86_64/build.sh
+++ b/cdt_cos6_x86_64/libxkbfile-devel-cos6-x86_64/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+mkdir -p ${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot
+mkdir -p ${PREFIX}/x86_64-conda-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd ${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .
+popd
+pushd ${PREFIX}/x86_64-conda-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .
+popd
+

--- a/cdt_cos6_x86_64/libxkbfile-devel-cos6-x86_64/meta.yaml
+++ b/cdt_cos6_x86_64/libxkbfile-devel-cos6-x86_64/meta.yaml
@@ -1,0 +1,33 @@
+package:
+  name: libxkbfile-devel-cos6-x86_64
+  version: 1.0.6
+
+source:
+  - url: https://vault.centos.org/centos/6.10/os/x86_64/Packages/libxkbfile-devel-1.0.6-1.1.el6.x86_64.rpm
+    sha256: 70edcd8315d8fa646e889ae46b1261a9efb055e623ab50134991820ee50ab630
+    no_hoist: true
+    folder: binary
+  - url: https://vault.centos.org/6.10/os/Source/SPackages/libxkbfile-1.0.6-1.1.el6.src.rpm
+    sha256: 555d3e4920aa3ff5eab1a82b360d601719628d79875288f76b519b72241b543a
+    folder: source
+
+build:
+  number: 1
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+requirements:
+  build:
+    - libxkbfile-cos6-x86_64 ==1.0.6
+  host:
+    - libxkbfile-cos6-x86_64 ==1.0.6
+  run:
+    - libxkbfile-cos6-x86_64 ==1.0.6
+
+about:
+  home: https://xorg.freedesktop.org/
+  license: MIT
+  license_family: MIT
+  summary: "(CDT) X.Org X11 libxkbfile development package"
+  description: libxkbfile is used by the X servers and utilities to parse the XKB configuration data files.


### PR DESCRIPTION
Add `libxkbfile` and `libxkbfile-devel` CDT for linux-64.

They will be build manually.

Required by:
* https://github.com/AnacondaRecipes/qt-webengine-feedstock/pull/5