### PR TITLE
Clean hdf5 in CBC

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -59,9 +59,6 @@ fortran_compiler_version:
   - 11.2.0                       # [osx or linux]
 clang_variant:
   - clang
-cyrus_sasl:
-  - 2.1.26  # [not ((osx and arm64) or (linux and aarch64))]
-  - 2.1.27  # [(osx and arm64) or (linux and aarch64)]
 dbus:
   - 1
 expat:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -96,8 +96,7 @@ harfbuzz:
 hdf4:
   - 4.2
 hdf5:
-  - 1.10.6  # [not (osx and arm64)]
-  - 1.12.1  # [osx and arm64]
+  - 1.12.1
 hdfeos2:
   - 2.20
 hdfeos5:


### PR DESCRIPTION
hdf5 1.12.1 has been correctly built on all platforms. We can now use it.

I also removed `cyrus_sasl` since it's not referenced in in our feedstocks.