### PR TITLE
rust-gnu reorg

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -35,9 +35,12 @@ m2w64_fortran_compiler:        # [win]
   - m2w64-toolchain            # [win]
 rust_compiler:
   - rust
-  - rust-gnu                   # [win]
 rust_compiler_version:
   - 1.71.1
+rust_gnu_compiler:             # [win]
+  - rust-gnu                   # [win]
+rust_gnu_compiler_version:     # [win]
+  - 1.71.1                     # [win]
 CONDA_BUILD_SYSROOT:
   - /opt/MacOSX10.10.sdk        # [osx and x86_64]
   - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [osx and arm64]

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -37,6 +37,7 @@ rust_compiler:
   - rust
 rust_compiler_version:
   - 1.71.1
+# use {{ compiler('rust-gnu') }} when requiring a build using the m2w64-toolchain 
 rust_gnu_compiler:             # [win]
   - rust-gnu                   # [win]
 rust_gnu_compiler_version:     # [win]


### PR DESCRIPTION
Make rust and rust-gnu separate configuration.
As most of the time we are adding extra code to skip the rust-gnu variant, this will result in simpler recipes.
Most recipes will still use `- {{ compiler('rust') }}` while recipes needing the gnu variant will use  `- {{ compiler('rust-gnu') }}`

Testing here: https://github.com/AnacondaRecipes/maturin-feedstock/pull/7