### PR TITLE
pin hdf5 to 1.12.1 and cyrus-sasl to 2.1.28

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -64,8 +64,7 @@ fortran_compiler_version:
 clang_variant:
   - clang
 cyrus_sasl:
-  - 2.1.26  # [not ((osx and arm64) or (linux and aarch64))]
-  - 2.1.27  # [(osx and arm64) or (linux and aarch64)]
+  - 2.1.28
 dbus:
   - 1
 expat:
@@ -100,8 +99,7 @@ harfbuzz:
 hdf4:
   - 4.2
 hdf5:
-  - 1.10.6  # [not (osx and arm64)]
-  - 1.12.1  # [osx and arm64]
+  - 1.12.1
 hdfeos2:
   - 2.20
 hdfeos5:


### PR DESCRIPTION
All currently maintained packages depending on hdf5 have been rebuilt against hdf5 1.12.1
All (most?) currently maintained packages depending on cyrus-sasl have been rebuilt against hdf5 2.1.28

Follow up of #295 