### PR TITLE
Fix indentation in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9904,7 +9904,7 @@
 [submodule "weasel-feedstock"]
 	path = weasel-feedstock
 	url = ../weasel-feedstock
-        branch = main
+    branch = main
 [submodule "phonetics-feedstock"]
 	path = phonetics-feedstock
 	url = ../phonetics-feedstock

--- a/.gitmodules
+++ b/.gitmodules
@@ -9904,7 +9904,7 @@
 [submodule "weasel-feedstock"]
 	path = weasel-feedstock
 	url = ../weasel-feedstock
-    branch = main
+	branch = main
 [submodule "phonetics-feedstock"]
 	path = phonetics-feedstock
 	url = ../phonetics-feedstock


### PR DESCRIPTION
There were 4 spaces instead of 1 tab.

Notes:
 - to unblock https://github.com/AnacondaRecipes/weasel-feedstock/pull/1