### PR TITLE
update libcurl, libtiff, libgdal, proj pins

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -108,6 +108,8 @@ icu:
   - 73
 jpeg:
   - 9
+libcurl:
+  - 8.1.1
 libdap4:
   - 3.19
 libffi:
@@ -115,7 +117,7 @@ libffi:
 libgd:
   - 2.3.3
 libgdal:
-  - 3.0
+  - 3.6.2
 libgsasl:
   - 1.10
 libkml:
@@ -125,8 +127,7 @@ libnetcdf:
 libpng:
   - 1.6
 libtiff:
-  - 4.1  # [not ((osx and arm64) or (linux and aarch64))]
-  - 4.2  # [(osx and arm64) or (linux and aarch64)]
+  - 4.2
 libwebp:
   - 1.3.2
 libxml2:
@@ -174,8 +175,7 @@ pixman:
 proj4:
   - 5.2.0
 proj:
-  - 6.2.1  # [not (osx and arm64)]
-  - 7.2.0  # [osx and arm64]
+  - 9.3.1
 libprotobuf:
   - 3.20.3
 python:


### PR DESCRIPTION
### Explanation of changes:
- Add libcurl pin to conda_build_config
- Update libgdal pin - rebuild was done against 3.6 a few months ago.
- Align libtiff pin. libtiff as a run_export on the major only, so this simplification is valid.
- Update proj pin, following rebuild of downstream deps.
