### PR TITLE
Add python 3.12 to the default build matrix

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -161,6 +161,8 @@ numpy:
   - 1.21
   # python 3.11
   - 1.23
+  # python 3.12
+  - 1.26
 openblas:
   - 0.3.21
 openjpeg:
@@ -183,6 +185,7 @@ python:
   - 3.9
   - "3.10"
   - "3.11"
+  - "3.12"
 python_implementation:
   - cpython
 python_impl:


### PR DESCRIPTION
Add python 3.12 to the default build matrix.