### PR TITLE
Add configuration for cuda compiler and version

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -24,6 +24,8 @@ cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]
   - vs2017                     # [win]
+cuda_compiler:
+  - cuda-nvcc
 fortran_compiler:
   - gfortran                   # [linux or osx]
   - intel-fortran              # [win]
@@ -58,6 +60,8 @@ c_compiler_version:        # [linux or osx]
 cxx_compiler_version:      # [linux or osx]
   - 11.2.0                 # [linux]
   - 14                     # [osx]
+cuda_compiler_version:
+  - 12.4
 fortran_compiler_version:
   - 2022.1.0                     # [win]
   - 11.2.0                       # [osx or linux]


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4806](https://anaconda.atlassian.net/browse/PKG-4806) 

### Explanation of changes:

- Required compiler packages are in defaults
- Entries added sort-of alphabetically with existing entries, but not so as to break up the c/c++ compiler entries.


[PKG-4806]: https://anaconda.atlassian.net/browse/PKG-4806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ