### PR TITLE
cbc: set default to vs2019

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -19,11 +19,11 @@ cairo:
 c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
-  - vs2017                     # [win]
+  - vs2019                     # [win]
 cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]
-  - vs2017                     # [win]
+  - vs2019                     # [win]
 cuda_compiler:
   - cuda-nvcc
 fortran_compiler:


### PR DESCRIPTION
### Explanation of changes:
https://anaconda.atlassian.net/browse/PKG-4890
A lot of upstream projects now require a minimum of vs2019 for their build. This is to avoid having to override the cbc in feedstocks.
