### PR TITLE
align cbc pins

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -2,9 +2,6 @@ pin_run_as_build:
   libboost:
     max_pin: x.x.x
 
-apr:
-  - 1.6.3  # [not (osx and arm64)]
-  - 1.7.0  # [osx and arm64]
 blas_impl:
   - mkl                        # [(x86 or x86_64) and not osx]
   - openblas                   # [not win]
@@ -93,8 +90,7 @@ giflib:
 glib:
   - 2
 gmp:
-  - 6.1  # [not (osx and arm64)]
-  - 6.2  # [osx and arm64]
+  - 6.2
 # glibc used in ctng compiler builds
 gnu:
   - 2.12.2
@@ -200,10 +196,7 @@ r_implementation:
   - 'r-base'
   - 'mro-base'  # [not osx]
 readline:
-  - 8.0    # [not ((linux and aarch64) or (osx and arm64))]
-  - 8.1    # [(linux and aarch64) or (osx and arm64)]
-serf:
-  - 1.3.9
+  - 8.1
 sqlite:
   - 3
 # This differs from target_platform in that it determines what subdir the compiler


### PR DESCRIPTION

### Links

- https://anaconda.atlassian.net/browse/PKG-5036

### Explanation of changes:

- remove apr and serf (both are required for svn only and do not justify a cbc entry).
- align gmp on 6.2. gmp has a run export on the major, no rebuild required.
- align readline on 8.1. readline has a run export on the major, no rebuild required.
