### PR TITLE
Add ucrt64-gcc-toolchain to cbc.yaml

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -32,6 +32,12 @@ m2w64_cxx_compiler:            # [win]
   - m2w64-toolchain            # [win]
 m2w64_fortran_compiler:        # [win]
   - m2w64-toolchain            # [win]
+ucrt64_c_compiler:             # [win]
+  - ucrt64-gcc-toolchain       # [win]
+ucrt64_cxx_compiler:           # [win]
+  - ucrt64-gcc-toolchain       # [win]
+ucrt64_fortran_compiler:       # [win]
+  - ucrt64-gcc-toolchain       # [win]
 rust_compiler:
   - rust
 rust_compiler_version:


### PR DESCRIPTION
This change works in concert with https://github.com/AnacondaRecipes/repack_msys2/pull/1

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-3301) 
- [Upstream repository](https://github.com/anaconda/msys2-build)

### Explanation of changes:

- Support ${env}-c_compiler, ${env}-cxx_compiler, ${env}-fortran_compiler metapackages, e.g.:
```
    - {{ compiler('ucrt64_c') }}         # [win]
    - {{ compiler('ucrt64_cxx') }}       # [win]
    - {{ compiler('ucrt64_fortran') }}   # [win]
```
see an example https://github.com/AnacondaRecipes/r-base-feedstock/blob/msys2-2024/recipe/meta.yaml#L62-L64C48
