### PR TITLE
Change the macos_machine value for osx-64

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -142,7 +142,7 @@ macos_min_version:
   - 10.15 # [osx and x86_64]
   - 11.1  # [osx and arm64]
 macos_machine:
-  - x86_64-apple-darwin13.4.0  # [osx and x86_64]
+  - x86_64-apple-darwin20.0.0  # [osx and x86_64]
   - arm64-apple-darwin20.0.0   # [osx and arm64]
 MACOSX_DEPLOYMENT_TARGET:
   - 10.15 # [osx and x86_64]


### PR DESCRIPTION
Change the `macos_machine` value for osx-64 after https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/pull/4.

https://anaconda.slack.com/archives/CBMB7R3QE/p1721318008882479