### PR TITLE
update cbc pins for libprotobuf, libabseil, libgrpc, libtiff, gstreamer

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -78,10 +78,10 @@ g2clib:
   - 1.6
 gstreamer:
   - 1.14  # [not win]
-  - 1.18  # [win]
+  - 1.22  # [win]
 gst_plugins_base:
   - 1.14  # [not win]
-  - 1.18  # [win]
+  - 1.22  # [win]
 geos:
   - 3.8.0  # [not (osx and arm64)]
   - 3.9.1  # [osx and arm64]
@@ -127,7 +127,7 @@ libnetcdf:
 libpng:
   - 1.6
 libtiff:
-  - 4.2
+  - 4.5.0
 libwebp:
   - 1.3.2
 libxml2:
@@ -179,7 +179,11 @@ proj4:
 proj:
   - 9.3.1
 libprotobuf:
-  - 3.20.3
+  - 4.25.3
+libabseil:
+  - 20240116.2
+libgrpc:
+  - 1.62.2
 python:
   - 3.8
   - 3.9


### PR DESCRIPTION
Updated cbc pins for libprotobuf, libabseil, libgrpc, libtiff, gstreamer.

Reason:
- libprotobuf, libabseil, libgrpc: updated libprotobuf
- libtiff 4.5 has additionals symbols that start to be required by upstream packages (e.g. opencv)
- gstreamer 1.18 on win has issues that were solved in 1.22.