### PR TITLE
Enable 3.13

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -185,6 +185,8 @@ numpy:
   - 1.23
   # python 3.12
   - 1.26
+  # python 3.13
+  - 2.1  # [ANACONDA_ROCKET_ENABLE_PY313=='yes']
 openblas:
   - 0.3.21
 openjpeg:
@@ -212,6 +214,7 @@ python:
   - "3.10"
   - "3.11"
   - "3.12"
+  - "3.13"  # [ANACONDA_ROCKET_ENABLE_PY313=='yes']
 python_implementation:
   - cpython
 python_impl:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -186,7 +186,7 @@ numpy:
   # python 3.12
   - 1.26
   # python 3.13
-  - 2.1  # [ANACONDA_ROCKET_ENABLE_PY313==1]
+  - 2.1  # [ANACONDA_ROCKET_ENABLE_PY313]
 openblas:
   - 0.3.21
 openjpeg:
@@ -214,7 +214,7 @@ python:
   - "3.10"
   - "3.11"
   - "3.12"
-  - "3.13"  # [ANACONDA_ROCKET_ENABLE_PY313==1]
+  - "3.13"  # [ANACONDA_ROCKET_ENABLE_PY313]
 python_implementation:
   - cpython
 python_impl:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -186,7 +186,7 @@ numpy:
   # python 3.12
   - 1.26
   # python 3.13
-  - 2.1  # [ANACONDA_ROCKET_ENABLE_PY313=='yes']
+  - 2.1  # [ANACONDA_ROCKET_ENABLE_PY313==1]
 openblas:
   - 0.3.21
 openjpeg:
@@ -214,7 +214,7 @@ python:
   - "3.10"
   - "3.11"
   - "3.12"
-  - "3.13"  # [ANACONDA_ROCKET_ENABLE_PY313=='yes']
+  - "3.13"  # [ANACONDA_ROCKET_ENABLE_PY313==1]
 python_implementation:
   - cpython
 python_impl:


### PR DESCRIPTION
### Explanation of changes:

With this change, one can add python 3.13 to the build matrix by:
- local builds: export ANACONDA_ROCKET_ENABLE_PY313=1
- prefect builds: adding to abs.yaml
```
build_env_vars:
  ANACONDA_ROCKET_ENABLE_PY313 : yes
```
