### PR TITLE
Relax libtiff pinning

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -149,7 +149,7 @@ libnetcdf:
 libpng:
   - 1.6
 libtiff:
-  - 4.5.0
+  - 4.5
 libwebp:
   - 1.3.2
 libxml2:


### PR DESCRIPTION
I'm trying to build `libtiff 4.5.1` with lerc 4 and libdeflate 1.22 ([PR](https://github.com/AnacondaRecipes/libtiff-feedstock/pull/20)) but also to fix a missing libtiff.lib on Windows. Relaxing the libtiff pinning will allow to use `libtiff {{ libtiff }}` in `host` of downstream packages (see [an example](https://github.com/AnacondaRecipes/poppler-feedstock/pull/18#issuecomment-2536077344)), otherwise, the ugly syntax will be needed:
```
    # libtiff 4.5.1 fixes a missing libtiff.lib on Windows
    - libtiff 4.5.1          # [win]
    - libtiff {{ libtiff }}  # [not win]
```