### PR TITLE
conda_build_config: update geos to 3.10.6

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -89,8 +89,7 @@ gst_plugins_base:
   - 1.14  # [not win]
   - 1.22  # [win]
 geos:
-  - 3.8.0  # [not (osx and arm64)]
-  - 3.9.1  # [osx and arm64]
+  - 3.10.6
 giflib:
   - 5
 glib:


### PR DESCRIPTION
conda_build_config: update geos to 3.10.6

### Links

- maybe [PKG-5039] ?

### Depends on

- AnacondaRecipes/geos-feedstock#11

### Explanation of changes:

- conda_build_config: update geos to 3.10.6


[PKG-5039]: https://anaconda.atlassian.net/browse/PKG-5039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ