### PR TITLE
Pin harfbuzz to 10

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -116,7 +116,7 @@ cgo_compiler:
 cgo_compiler_version:
   - 1.21              # [not s390x]
 harfbuzz:
-  - 4.3.0
+  - 10
 hdf4:
   - 4.2
 hdf5:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7052](https://anaconda.atlassian.net/browse/PKG-7052) 

### Explanation of changes:

- Pin `harfbuzz` to `10`

### Notes:

- All downstream packages have been built with `harfbuzz 10`. See the [Epic](https://anaconda.atlassian.net/browse/PKG-6994)

[PKG-7052]: https://anaconda.atlassian.net/browse/PKG-7052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ