### PR TITLE
Add `{{ stdlib('c') }}` jinja function for recipes

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -17,7 +17,7 @@ c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
   - vs2019                     # [win]
-c_stdlib                       # [linux]
+c_stdlib:                      # [linux]
   - sysroot                    # [linux]
 cxx_compiler:
   - gxx                        # [linux]

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -17,6 +17,8 @@ c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
   - vs2019                     # [win]
+c_stdlib                       # [linux]
+  - sysroot                    # [linux]
 cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]
@@ -60,6 +62,9 @@ cran_mirror:
 c_compiler_version:        # [linux or osx]
   - 11.2.0                 # [linux]
   - 14                     # [osx]
+c_stdlib_version:          # [linux]
+  - 2.17                   # [linux and not aarch64]
+  - 2.26                   # [linux and aarch64]
 cxx_compiler_version:      # [linux or osx]
   - 11.2.0                 # [linux]
   - 14                     # [osx]


### PR DESCRIPTION
**Destination channel:** defaults

### Explanation of changes:

- This enables you to put ` {{ stdlib('c') }}` in recipes
- currently it won't do anything, as the sysroot packages are pulled in by the compilers anyway, and the versions are (I assume?) tied together
- It does allow us to reduce a class of diffs when pulling across conda recipes (that is, we don't have to comment out ` {{ stdlib('c') }}`)

See https://docs.conda.io/projects/conda-build/en/stable/resources/compiler-tools.html#expressing-the-relation-between-compiler-and-its-standard-library for more details.