### PR TITLE
Update R version to 4.3.1 in cbc.yaml

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -216,10 +216,9 @@ python_implementation:
 python_impl:
   - cpython
 r_version:
-  - 3.5.0
+  - 4.3.1
 r_implementation:
-  - 'r-base'
-  - 'mro-base'  # [not osx]
+  - 'r-base'    # [linux and x86_64]
 readline:
   - 8.1
 sqlite:


### PR DESCRIPTION
Rationale:
 - We already built `R` packages with `r-base 4.3.1` on `linux-64`, and **v4.3.1** is our current version.
 - Some R feedstocks are located in the `aggregate` repo (not `aggregateR`), for example [r-base-feedstock](https://github.com/AnacondaRecipes/r-base-feedstock).
 - We do not build R packages for **non**-linux-64 platforms currently.
