### PR TITLE
Pin libtiff to 4.7

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -148,7 +148,7 @@ libnetcdf:
 libpng:
   - 1.6
 libtiff:
-  - 4.5
+  - 4.7
 libwebp:
   - 1.3.2
 libxml2:


### PR DESCRIPTION
### Links

- [PKG-7881](https://anaconda.atlassian.net/browse/PKG-7881) 
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/libtiff-feedstock/pull/21
  - https://github.com/AnacondaRecipes/r-base-feedstock/pull/3
    - https://github.com/AnacondaRecipes/aggregateR/pull/18
  - https://github.com/AnacondaRecipes/gdk-pixbuf-feedstock/pull/6
  - https://github.com/AnacondaRecipes/openjpeg-feedstock/pull/6
  - https://github.com/AnacondaRecipes/libwebp-feedstock/pull/9
  - https://github.com/AnacondaRecipes/lcms2-feedstock/pull/2
  - https://github.com/AnacondaRecipes/proj.4-feedstock/pull/9
  - https://github.com/AnacondaRecipes/geotiff-feedstock/pull/12
  - https://github.com/AnacondaRecipes/devil-feedstock/pull/4
  - https://github.com/AnacondaRecipes/qtimageformats-feedstock/pull/3
  - https://github.com/AnacondaRecipes/libgd-feedstock/pull/8
  - https://github.com/AnacondaRecipes/leptonica-feedstock/pull/5
  - https://github.com/AnacondaRecipes/poppler-feedstock/pull/20
  - https://github.com/AnacondaRecipes/pillow-feedstock/pull/31
  - https://github.com/AnacondaRecipes/imagecodecs-feedstock/pull/18
  - https://github.com/AnacondaRecipes/gdal-feedstock/pull/31
  - https://github.com/AnacondaRecipes/opencv-feedstock/pull/36
  - https://github.com/AnacondaRecipes/vtk-feedstock/pull/23
  - (WIP) https://github.com/AnacondaRecipes/qtwebengine-feedstock/pull/2

### Explanation of changes:

- Pin libtiff to `4.7`

### Notes:

- It's safe to merge this PR because we already applied the hotfix for `libtiff` to use the upper bound <4.7.0 https://github.com/AnacondaRecipes/repodata-hotfixes/pull/252
- For maintainability, I'll replace `libtiff 4.7.0` with `libtiff {{ libtiff }}` on all downstream feedstocks after merging this PR.


[PKG-7881]: https://anaconda.atlassian.net/browse/PKG-7881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ