### PR TITLE
augment pinnings in conda_build_config.yaml

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -603,14 +603,12 @@ nss:
   - '3'
 ntbtls:
   - '0'
-numpy:
-  - ''
 ocl_icd:
   - '2'
 oniguruma:
   - '6.9'
 openblas:
-  - 0.3.29
+  - 0
 openh264:
   - '2.6'
 openjpeg:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,3 +1,6 @@
+## GLOBAL config
+## Compilers, blas, R, python...
+
 pin_run_as_build:
   libboost:
     max_pin: x.x.x
@@ -5,14 +8,6 @@ pin_run_as_build:
 blas_impl:
   - mkl                        # [(x86 or x86_64) and not osx]
   - openblas                   # [not win]
-boost:
-  - 1.82
-boost_cpp:
-  - 1.82
-bzip2:
-  - 1.0
-cairo:
-  - 1.16
 c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
@@ -69,6 +64,89 @@ fortran_compiler_version:
   - 11.2.0                       # [osx or linux]
 clang_variant:
   - clang
+# The basic go-compiler with CGO disabled (CGO_ENABLED=0).
+# It generates fat binaries without libc dependencies.
+go_compiler:
+  - go-nocgo
+go_compiler_version:
+  - 1.21
+# The go compiler build with CGO enabled (CGO_ENABLED=1).
+# It can generate fat binaries that depend on conda's libc.
+# You should use this compiler if the underlying
+# program needs to link against other C libraries, in which
+# case make sure to add 'c,cpp,fortran_compiler' for unix
+# and the m2w64 equivalent for windows.
+cgo_compiler:
+  - go-cgo
+cgo_compiler_version:
+  - 1.21
+macos_min_version:
+  - 10.15 # [osx and x86_64]
+  - 11.1  # [osx and arm64]
+macos_machine:
+  - x86_64-apple-darwin13.4.0  # [osx and x86_64]
+  - arm64-apple-darwin20.0.0   # [osx and arm64]
+MACOSX_DEPLOYMENT_TARGET:
+  - 10.15 # [osx and x86_64]
+  - 11.1  # [osx and arm64]
+python:
+  - 3.9
+  - "3.10"
+  - "3.11"
+  - "3.12"
+  - "3.13"
+# numpy will by default use a compatible ABI for the oldest still-supported numpy versions
+# `{{ pin_compatible("numpy") }}` is no longer needed as builds of numpy from version 2 have run_exports.
+numpy:
+  # python 3.9
+  - 2.0
+  # python 3.10
+  - 2.0
+  # python 3.11
+  - 2.0
+  # python 3.12
+  - 2.0
+  # python 3.13
+  - 2.1
+zip_keys:
+  -
+    - python
+    - numpy
+python_implementation:
+  - cpython
+python_impl:
+  - cpython
+r_base:
+  - 4.3.1
+r_version:
+  - 4.3.1
+r_implementation:
+  - 'r-base'    # [linux and x86_64]
+# This differs from target_platform in that it determines what subdir the compiler
+#    will target, not what subdir the compiler package will be itself.
+#    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32
+#    code on win-64 miniconda.
+cross_compiler_target_platform:
+  # - win-32                     # [win]
+  - win-64                     # [win]
+target_platform:
+  - win-64                     # [win]
+  # - win-32                     # [win]
+channel_targets:
+  - defaults
+cdt_name:
+  - amzn2    # [linux and aarch64]
+
+
+## GLOBAL pinnings
+boost:
+  - 1.82
+boost_cpp:
+  - 1.82
+bzip2:
+  - 1.0
+cairo:
+  - 1.16
 cyrus_sasl:
   - 2.1.28
 dbus:
@@ -81,10 +159,6 @@ freetype:
   - 2.10
 g2clib:
   - 1.6
-gstreamer:
-  - 1.24
-gst_plugins_base:
-  - 1.24
 geos:
   - 3.10.6
 giflib:
@@ -93,25 +167,10 @@ glib:
   - 2
 gmp:
   - 6.3
-# glibc used in ctng compiler builds
-gnu:
-  - 2.12.2
-# The basic go-compiler with CGO disabled (CGO_ENABLED=0).
-# It generates fat binaries without libc dependencies.
-go_compiler:
-  - go-nocgo          # [not s390x]
-go_compiler_version:
-  - 1.21              # [not s390x]
-# The go compiler build with CGO enabled (CGO_ENABLED=1).
-# It can generate fat binaries that depend on conda's libc.
-# You should use this compiler if the underlying
-# program needs to link against other C libraries, in which
-# case make sure to add 'c,cpp,fortran_compiler' for unix
-# and the m2w64 equivalent for windows.
-cgo_compiler:
-  - go-cgo            # [not s390x]
-cgo_compiler_version:
-  - 1.21              # [not s390x]
+gstreamer:
+  - 1.24
+gst_plugins_base:
+  - 1.24
 harfbuzz:
   - 10
 hdf4:
@@ -126,6 +185,8 @@ icu:
   - 73
 jpeg:
   - 9
+libabseil:
+  - 20250127.0
 libcurl:
   - 8.1.1
 libdap4:
@@ -136,6 +197,8 @@ libgd:
   - 2.3.3
 libgdal:
   - 3.6.2
+libgrpc:
+  - 1.71.0
 libgsasl:
   - 1.10
 libkml:
@@ -144,6 +207,8 @@ libnetcdf:
   - 4.8
 libpng:
   - 1.6
+libprotobuf:
+  - 5.29.3
 libtiff:
   - 4.7
 libwebp:
@@ -152,36 +217,12 @@ libxml2:
   - 2.13
 libxslt:
   - 1.1
-llvm_variant:
-  - llvm
 lzo:
   - 2
-macos_min_version:
-  - 10.15 # [osx and x86_64]
-  - 11.1  # [osx and arm64]
-macos_machine:
-  - x86_64-apple-darwin13.4.0  # [osx and x86_64]
-  - arm64-apple-darwin20.0.0   # [osx and arm64]
-MACOSX_DEPLOYMENT_TARGET:
-  - 10.15 # [osx and x86_64]
-  - 11.1  # [osx and arm64]
 mkl:
-  - 2023.*
+  - 2023
 mpfr:
   - 4
-# numpy will by default use a compatible ABI for the oldest still-supported numpy versions
-# `{{ pin_compatible("numpy") }}` is no longer needed as builds of numpy from version 2 have run_exports.
-numpy:
-  # python 3.9
-  - 2.0
-  # python 3.10
-  - 2.0
-  # python 3.11
-  - 2.0
-  # python 3.12
-  - 2.0
-  # python 3.13
-  - 2.1
 openblas:
   - 0.3.21
 openjpeg:
@@ -192,61 +233,21 @@ perl:
   - 5.38
 pixman:
   - 0.40
-proj4:
-  - 5.2.0
 proj:
   - 9.3.1
-libprotobuf:
-  - 5.29.3
-libabseil:
-  - 20250127.0
-libgrpc:
-  - 1.71.0
-python:
-  - 3.9
-  - "3.10"
-  - "3.11"
-  - "3.12"
-  - "3.13"
-python_implementation:
-  - cpython
-python_impl:
-  - cpython
-r_base:
-  - 4.3.1
-r_version:
-  - 4.3.1
-r_implementation:
-  - 'r-base'    # [linux and x86_64]
+proj4:
+  - 5.2.0
 readline:
   - 8.1
 sqlite:
   - 3
-# This differs from target_platform in that it determines what subdir the compiler
-#    will target, not what subdir the compiler package will be itself.
-#    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32
-#    code on win-64 miniconda.
-cross_compiler_target_platform:
-  # - win-32                     # [win]
-  - win-64                     # [win]
-target_platform:
-  - win-64                     # [win]
-  # - win-32                     # [win]
 tk:
   - 8.6
 vc:
-  - 14                         # [win]
-zlib:
-  - 1.2
+  - 14
 xz:
   - 5
-channel_targets:
-  - defaults
-cdt_name:
-  - amzn2    # [linux and aarch64]
-zip_keys:
-  -
-    - python
-    - numpy
+zlib:
+  - 1.2
 zstd:
   - 1.5.2

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -607,7 +607,7 @@ oniguruma:
   - '6.9'
 openblas:
   - 0
-openblas-devel:
+openblas_devel:
   - '0'
 openh264:
   - '2.6'

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -479,8 +479,6 @@ libntlm:
   - '1'
 libogg:
   - '1.3'
-libopenblas:
-  - '0'
 libopengl:
   - '1'
 libopus:
@@ -609,6 +607,8 @@ oniguruma:
   - '6.9'
 openblas:
   - 0
+openblas-devel:
+  - '0'
 openh264:
   - '2.6'
 openjpeg:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -139,42 +139,188 @@ cdt_name:
 
 
 ## GLOBAL pinnings
+alsa_lib:
+  - '1.2'
+ampl_mp:
+  - '3.1'
+aom:
+  - '3.6'
+armadillo:
+  - '12'
+arpack:
+  - '3.9'
+arrow_cpp:
+  - 19.0.0
+assimp:
+  - 5.4.3
+at_spi2_core:
+  - '2.36'
+atk_1.0:
+  - 2.36.0
+aws_c_auth:
+  - 0.8.5
+aws_c_cal:
+  - 0.8.5
+aws_c_common:
+  - 0.11.1
+aws_c_compression:
+  - 0.3.1
+aws_c_event_stream:
+  - 0.5.4
+aws_c_http:
+  - 0.9.3
+aws_c_io:
+  - 0.17.0
+aws_c_mqtt:
+  - 0.12.2
+aws_c_s3:
+  - 0.7.11
+aws_c_sdkutils:
+  - 0.2.3
+aws_checksums:
+  - 0.2.3
+aws_crt_cpp:
+  - 0.31.0
+aws_sdk_cpp:
+  - 1.11.528
+azure_core_cpp:
+  - 1.14.1
+azure_identity_cpp:
+  - 1.10.1
+azure_storage_blobs_cpp:
+  - 12.13.0
+azure_storage_common_cpp:
+  - 12.10.0
+backtrace:
+  - '20241216'
+blosc:
+  - '1'
 boost:
   - 1.82
 boost_cpp:
   - 1.82
+brunsli:
+  - '0'
 bzip2:
-  - 1.0
+  - '1'
+c_ares:
+  - '1'
+c_blosc2:
+  - '2'
 cairo:
-  - 1.16
+  - '1'
+capnproto:
+  - 1.1.0
+ceres_solver:
+  - '2.2'
+cfitsio:
+  - '3.470'
+charls:
+  - '2.2'
+coin_or_cbc:
+  - '2.10'
+coin_or_cgl:
+  - '0.60'
+coin_or_clp:
+  - '1.17'
+coin_or_osi:
+  - '0.108'
+coin_or_utils:
+  - '2.11'
+cudnn:
+  - '9'
+cutensor:
+  - '2'
 cyrus_sasl:
   - 2.1.28
+dav1d:
+  - 1.2.1
 dbus:
-  - 1
+  - '1'
+eigen:
+  - 3.3.7
+epoxy:
+  - '1.5'
 expat:
-  - 2
+  - '2'
+ffmpeg:
+  - '6'
+fftw:
+  - '3.3'
+flatbuffers:
+  - 24.3.25
+fmt:
+  - '9'
 fontconfig:
-  - 2.14
+  - '2'
+freeglut:
+  - '3'
+freetds:
+  - '1'
 freetype:
-  - 2.10
+  - '2'
+freexl:
+  - '2'
+fribidi:
+  - '1'
 g2clib:
-  - 1.6
+  - '1.6'
+gcab:
+  - '1'
+gdbm:
+  - '1.18'
+gdk_pixbuf:
+  - '2'
 geos:
   - 3.10.6
+geotiff:
+  - '1.7'
+gettext:
+  - '0'
+gflags:
+  - '2.2'
 giflib:
-  - 5
+  - '5.2'
+gl2ps:
+  - 1.4.2
+glew:
+  - '2.2'
 glib:
   - 2
+glog:
+  - '0.5'
+glpk:
+  - '4.65'
+glslang:
+  - '15'
 gmp:
-  - 6.3
-gstreamer:
-  - 1.24
+  - '6'
+gnupg:
+  - '2.4'
+gnutls:
+  - '3.8'
+graphite2:
+  - '1'
+gsl:
+  - '2.7'
 gst_plugins_base:
   - 1.24
+gst_plugins_good:
+  - '1.24'
+gstreamer:
+  - '1.24'
+gstreamer_orc:
+  - '0.4'
+gtest:
+  - 1.14.0
+gtk3:
+  - '3'
+gts:
+  - '0.7'
 harfbuzz:
-  - 10
+  - '10'
 hdf4:
-  - 4.2
+  - 4.2.13
 hdf5:
   - 1.14.5
 hdfeos2:
@@ -182,72 +328,472 @@ hdfeos2:
 hdfeos5:
   - 5.1
 icu:
-  - 73
+  - '73'
+igraph:
+  - '0.10'
+isl:
+  - '0.22'
+jansson:
+  - '2'
+jasper:
+  - '4'
+jemalloc:
+  - '5'
 jpeg:
-  - 9
+  - 9e
+json_c:
+  - '0.16'
+jsoncpp:
+  - 1.9.4
+jxrlib:
+  - '1.1'
+kealib:
+  - '1.5'
+krb5:
+  - '1.21'
+lame:
+  - '3.100'
+lcms2:
+  - '2'
+leptonica:
+  - '1.82'
+lerc:
+  - '4'
+leveldb:
+  - '1.23'
 libabseil:
-  - 20250127.0
+  - '20250127.0'
+libaec:
+  - '1'
+libaio:
+  - '0.3'
+libapr:
+  - '1'
+libapriconv:
+  - '1'
+libaprutil:
+  - '1'
+libarchive:
+  - '3.7'
+libassuan:
+  - '3'
+libavif:
+  - '1'
+libbrotlicommon:
+  - '1.0'
+libbrotlidec:
+  - '1.0'
+libbrotlienc:
+  - '1.0'
+libclang_cpp14:
+  - '14.0'
+libclang13:
+  - '14.0'
+libcrc32c:
+  - '1.1'
+libcryptominisat:
+  - '5.6'
 libcurl:
-  - 8.1.1
+  - '8'
 libdap4:
-  - 3.19
+  - '3.19'
+libdb:
+  - '6.2'
+libde265:
+  - 1.0.15
+libdeflate:
+  - '1.22'
+libdrm:
+  - '2.4'
+libebm:
+  - 0.4.4
+libedit:
+  - '3.1'
+libegl:
+  - '1'
+libevent:
+  - 2.1.12
+libfaiss:
+  - 1.0.0
 libffi:
-  - 3.4
+  - '3.4'
+libflac:
+  - '1.4'
+libgcrypt:
+  - '1'
 libgd:
-  - 2.3.3
+  - '2.3'
 libgdal:
-  - 3.6.2
+  - '3.6'
+libgit2:
+  - '1.6'
+libgl:
+  - '1'
+libgles:
+  - '1'
+libglib:
+  - '2'
+libglvnd:
+  - '1'
+libglx:
+  - '1'
+libgpg_error:
+  - '1'
 libgrpc:
-  - 1.71.0
+  - '1.71'
 libgsasl:
-  - 1.10
+  - '1'
+libgsf:
+  - '1.14'
+libheif:
+  - '1.19'
+libiconv:
+  - '1'
+libidn2:
+  - '2'
+libjpeg_turbo:
+  - '3'
 libkml:
-  - 1.3
+  - '1.3'
+libksba:
+  - '1.6'
+liblief:
+  - '0.16'
+libllvm19:
+  - '19.1'
+libmamba:
+  - '2.0'
+libmambapy:
+  - '2.0'
+libmicrohttpd:
+  - '0.9'
+libmlir19:
+  - '19.1'
 libnetcdf:
-  - 4.8
+  - '4'
+libnghttp2:
+  - '1'
+libnsl:
+  - '2.0'
+libntlm:
+  - '1'
+libogg:
+  - '1.3'
+libopenblas:
+  - '0'
+libopengl:
+  - '1'
+libopus:
+  - '1'
+libortools:
+  - '9.9'
+libosqp:
+  - 0.6.3
+libpcap:
+  - '1.10'
+libpciaccess:
+  - '0.18'
 libpng:
-  - 1.6
+  - '1.6'
+libpq:
+  - '17'
 libprotobuf:
   - 5.29.3
+libqdldl:
+  - 0.1.7
+librdkafka:
+  - '2.2'
+libre2_11:
+  - '2024'
+librsvg:
+  - '2'
+libsentencepiece:
+  - 0.2.0
+libsndfile:
+  - '1.2'
+libsodium:
+  - 1.0.18
+libspatialindex:
+  - 1.9.3
+libspatialite:
+  - '5.1'
+libssh2:
+  - '1'
+libtasn1:
+  - '4'
+libtensorflow:
+  - 2.18.1
+libtensorflow_cc:
+  - 2.18.1
+libtheora:
+  - '1'
+libthrift:
+  - '0.15'
 libtiff:
-  - 4.7
+  - '4'
+libtorch:
+  - '2.5'
+libunistring:
+  - '0'
+libunwind:
+  - '1'
+libutf8proc:
+  - '2'
+libuuid:
+  - '1'
+libuv:
+  - '1'
+libvorbis:
+  - '1'
+libvpx:
+  - '1.13'
 libwebp:
   - 1.3.2
+libwebp_base:
+  - '1'
+libxcb:
+  - '1'
+libxkbcommon:
+  - '1'
 libxml2:
-  - 2.13
+  - '2.13'
+libxmlsec1:
+  - '1.3'
 libxslt:
-  - 1.1
+  - '1'
+libzopfli:
+  - '1.0'
+lmdb:
+  - '0'
+lz4_c:
+  - '1.9'
 lzo:
-  - 2
+  - '2'
+mbedtls:
+  - '3.5'
+metis:
+  - '5.1'
+minizip:
+  - '4'
 mkl:
-  - 2023
+  - '2025'
+mkl_service:
+  - '2'
+mpc:
+  - '1'
 mpfr:
-  - 4
+  - '4'
+mpich:
+  - '4'
+nanobind_abi:
+  - '15'
+nccl:
+  - '2'
+ncurses:
+  - '6'
+nettle:
+  - '3.7'
+nlopt:
+  - '2.7'
+npth:
+  - '1'
+nspr:
+  - '4'
+nss:
+  - '3'
+ntbtls:
+  - '0'
+numpy:
+  - ''
+ocl_icd:
+  - '2'
+oniguruma:
+  - '6.9'
 openblas:
   - 0.3.21
+openh264:
+  - '2.6'
 openjpeg:
-  - 2.3
+  - '2'
+openldap:
+  - '2.6'
+openmpi:
+  - '4.1'
 openssl:
-  - 3.0
+  - '3'
+orc:
+  - 2.1.1
+pango:
+  - '1'
+pcre:
+  - '8'
+pcre2:
+  - '10.42'
+pdal:
+  - '2.5'
 perl:
   - 5.38
 pixman:
-  - 0.40
+  - '0'
+popt:
+  - '1'
 proj:
   - 9.3.1
 proj4:
   - 5.2.0
+ptscotch:
+  - 6.0.9
+pugixml:
+  - '1.11'
+py_lief:
+  - '0.16'
+pybind11_abi:
+  - '5'
+pyqt:
+  - '6.7'
+pyqtwebengine:
+  - '6.7'
+python_igraph:
+  - '0.10'
+pytorch:
+  - '2.5'
+qhull:
+  - '2020.2'
+qpdf:
+  - '11'
+qt:
+  - '6.7'
+quantlib:
+  - '1'
+rdkit:
+  - 2023.03.3
+re2:
+  - '2024'
 readline:
-  - 8.1
+  - '8'
+reproc:
+  - '14.2'
+reproc_cpp:
+  - '14.2'
+rhash:
+  - '1'
+ruby:
+  - '3.2'
+s2n:
+  - 1.5.14
+scotch:
+  - 6.0.9
+serf:
+  - '1.3'
+simdjson:
+  - '3.10'
+sip:
+  - '6.10'
+sleef:
+  - '3'
+snappy:
+  - '1'
+spdlog:
+  - '1'
+spdlog_fmt_embed:
+  - '1'
+spirv_tools:
+  - '2025'
 sqlite:
-  - 3
+  - '3'
+suitesparse:
+  - '7'
+tesseract:
+  - 5.2.0
+tiledb:
+  - '2.26'
 tk:
-  - 8.6
+  - '8.6'
+unixodbc:
+  - '2.3'
 vc:
-  - 14
+  - '14'
+vs2015_runtime:
+  - '14'
+vtk_base:
+  - 9.4.1
+vtk_io_ffmpeg:
+  - 9.4.1
+x264:
+  - 1!152.20180806
+xcb_util:
+  - '0.4'
+xcb_util_cursor:
+  - '0.1'
+xcb_util_image:
+  - '0.4'
+xcb_util_keysyms:
+  - '0.4'
+xcb_util_renderutil:
+  - '0.3'
+xcb_util_wm:
+  - '0.4'
+xerces_c:
+  - '3.2'
+xorg_libice:
+  - '1'
+xorg_libsm:
+  - '1'
+xorg_libx11:
+  - '1'
+xorg_libxau:
+  - '1'
+xorg_libxcomposite:
+  - '0'
+xorg_libxcursor:
+  - '1'
+xorg_libxdamage:
+  - '1'
+xorg_libxdmcp:
+  - '1'
+xorg_libxext:
+  - '1'
+xorg_libxfixes:
+  - '6'
+xorg_libxft:
+  - '2'
+xorg_libxi:
+  - '1'
+xorg_libxinerama:
+  - '1.1'
+xorg_libxmu:
+  - '1'
+xorg_libxrandr:
+  - '1'
+xorg_libxrender:
+  - '0.9'
+xorg_libxscrnsaver:
+  - '1'
+xorg_libxshmfence:
+  - '1'
+xorg_libxt:
+  - '1'
+xorg_libxtst:
+  - '1'
+xorg_libxxf86vm:
+  - '1'
+xorg_xextproto:
+  - '7'
+xorg_xorgproto:
+  - '2024'
+xxhash:
+  - 0.8.0
 xz:
-  - 5
+  - '5'
+yaml:
+  - '0.2'
+yaml_cpp:
+  - '0.8'
+zfp:
+  - '1'
 zlib:
-  - 1.2
+  - '1.2'
+zlib_ng:
+  - '2.0'
 zstd:
-  - 1.5.2
+  - '1.5'

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -385,9 +385,9 @@ libbrotlidec:
   - '1.0'
 libbrotlienc:
   - '1.0'
-libclang_cpp14:
-  - '14.0'
 libclang13:
+  - '14.0'
+libclang_cpp14:
   - '14.0'
 libcrc32c:
   - '1.1'
@@ -480,7 +480,7 @@ libntlm:
 libogg:
   - '1.3'
 libopenblas:
-  - 0.3.29
+  - '0'
 libopengl:
   - '1'
 libopus:
@@ -639,8 +639,6 @@ popt:
   - '1'
 proj:
   - 9.3.1
-proj4:
-  - 5.2.0
 ptscotch:
   - 6.0.9
 pugixml:
@@ -712,8 +710,6 @@ tk:
 unixodbc:
   - '2.3'
 vc:
-  - '14'
-vs2015_runtime:
   - '14'
 vtk_base:
   - 9.4.1

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -480,7 +480,7 @@ libntlm:
 libogg:
   - '1.3'
 libopenblas:
-  - '0'
+  - 0.3.29
 libopengl:
   - '1'
 libopus:
@@ -576,7 +576,7 @@ metis:
 minizip:
   - '4'
 mkl:
-  - '2025'
+  - '2023'
 mkl_service:
   - '2'
 mpc:
@@ -610,7 +610,7 @@ ocl_icd:
 oniguruma:
   - '6.9'
 openblas:
-  - 0.3.21
+  - 0.3.29
 openh264:
   - '2.6'
 openjpeg:


### PR DESCRIPTION
augment pinnings in conda_build_config.yaml 

- reorganize cbc to separate compilers and main variants configuration from package pinnings
- pin active package on the main channel that have run_exports defined

The pinnings are updated using script cbc-increment currently at https://github.com/anaconda/distro-incubator/pull/117