### PR TITLE
Added stdlib versions for Linux, set cdt_name to el8

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -12,6 +12,8 @@ c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
   - vs2019                     # [win]
+c_stdlib:
+  - sysroot                    # [linux]
 cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]
@@ -54,6 +56,9 @@ cran_mirror:
 c_compiler_version:        # [linux or osx]
   - 11.2.0                 # [linux]
   - 14                     # [osx]
+c_stdlib_version:          # [unix]
+  - 2.17                   # [linux and (not ANACONDA_ROCKET_GLIBC or ANACONDA_ROCKET_GLIBC == "2.17")]
+  - 2.28                   # [linux and ANACONDA_ROCKET_GLIBC == "2.28"]
 cxx_compiler_version:      # [linux or osx]
   - 11.2.0                 # [linux]
   - 14                     # [osx]
@@ -134,9 +139,13 @@ target_platform:
   # - win-32                     # [win]
 channel_targets:
   - defaults
-cdt_name:
-  - amzn2    # [linux and aarch64]
+cdt_name:          # [linux]
+  - amzn2          # [linux and aarch64 and (not ANACONDA_ROCKET_GLIBC or ANACONDA_ROCKET_GLIBC == "2.17")]
+  - el8            # [linux and ANACONDA_ROCKET_GLIBC == "2.28"]
 
+# https://github.com/conda/conda-build/issues/5733
+BUILD: x86_64-conda_el8-linux-gnu   # [linux and x86_64 and ANACONDA_ROCKET_GLIBC == "2.28"]
+BUILD: aarch64-conda_el8-linux-gnu  # [linux and aarch64 and ANACONDA_ROCKET_GLIBC == "2.28"]
 
 ## GLOBAL pinnings
 alsa_lib:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -57,7 +57,8 @@ c_compiler_version:        # [linux or osx]
   - 11.2.0                 # [linux]
   - 14                     # [osx]
 c_stdlib_version:          # [unix]
-  - 2.17                   # [linux and (not ANACONDA_ROCKET_GLIBC or ANACONDA_ROCKET_GLIBC == "2.17")]
+  - 2.17                   # [linux and x86_64 and (not ANACONDA_ROCKET_GLIBC or ANACONDA_ROCKET_GLIBC == "2.17")]
+  - 2.26                   # [linux and aarch64 and (not ANACONDA_ROCKET_GLIBC or ANACONDA_ROCKET_GLIBC == "2.26")]
   - 2.28                   # [linux and ANACONDA_ROCKET_GLIBC == "2.28"]
 cxx_compiler_version:      # [linux or osx]
   - 11.2.0                 # [linux]
@@ -140,7 +141,7 @@ target_platform:
 channel_targets:
   - defaults
 cdt_name:          # [linux]
-  - amzn2          # [linux and aarch64 and (not ANACONDA_ROCKET_GLIBC or ANACONDA_ROCKET_GLIBC == "2.17")]
+  - amzn2          # [linux and aarch64 and (not ANACONDA_ROCKET_GLIBC or ANACONDA_ROCKET_GLIBC == "2.26")]
   - el8            # [linux and ANACONDA_ROCKET_GLIBC == "2.28"]
 
 # https://github.com/conda/conda-build/issues/5733


### PR DESCRIPTION
[PKG-7919](https://anaconda.atlassian.net/browse/PKG-7919)

### Explanation of changes:

- Added variables for the expansion of a new jinja macro: `{{ stdlib('c') }}`
  - This update only affects Linux and should be used, for now, in recipes with the `# [linux]` preprocessor.
- These changes are heavily dependent on a new Rocky 8 docker, a new Rocky 8-based sysroot, and a new set of Rocky 8 CDTs existing
  - Anaconda/docker-images#659 to allow recipes to test with Rocky 8 in Prefect by using `pkg_build_image_tag: main-rockylinux-8` in their `abs.yaml`
  - AnacondaRecipes/linux-sysroot-feedstock#3 to provide a sysroot package compatible with what `stdlib('c')` evaluates to: `sysroot_linux-64 2.28`
  - AnacondaRecipes/cdt_el8_x86_64-feedstock#1 to ensure that `cdt_name=el8` has CDTs available

These changes should only be merged once all other work is completed and the default image being used in CI has switched to the Rocky 8 image.

[PKG-7919]: https://anaconda.atlassian.net/browse/PKG-7919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ