### PR TITLE
Add sysroot versions for OSX

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -139,11 +139,14 @@ cdt_name:          # [linux]
 BUILD: x86_64-conda_el8-linux-gnu   # [linux and x86_64 and ANACONDA_ROCKET_GLIBC == "2.28"]
 BUILD: aarch64-conda_el8-linux-gnu  # [linux and aarch64 and ANACONDA_ROCKET_GLIBC == "2.28"]
 
-# TODO: These are only necessary as we transition to using the stdlib('c') macro. They should be
-# removed once it is safe to do so.
 OSX_SDK_DIR:
   - /opt                                      # [osx and x86_64]
   - /Library/Developer/CommandLineTools/SDKs  # [osx and arm64]
+# TODO: These are only necessary as we transition to using the stdlib('c') macro. They should be
+# removed once it is safe to do so.
+CONDA_BUILD_SYSROOT:
+  - /opt/MacOSX10.15.sdk        # [osx and x86_64]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [osx and arm64]
 macos_min_version:
   - 10.15 # [osx and x86_64]
   - 11.1  # [osx and arm64]

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -14,6 +14,7 @@ c_compiler:
   - vs2019                     # [win]
 c_stdlib:
   - sysroot                    # [linux]
+  - macosx_deployment_target   # [osx]
 cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]
@@ -44,9 +45,6 @@ rust_gnu_compiler:             # [win]
   - rust-gnu                   # [win]
 rust_gnu_compiler_version:     # [win]
   - 1.87.0                     # [win]
-CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.15.sdk        # [osx and x86_64]
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [osx and arm64]
 VERBOSE_AT:
   - V=1
 VERBOSE_CM:
@@ -60,6 +58,8 @@ c_stdlib_version:          # [unix]
   - 2.17                   # [linux and x86_64 and (not ANACONDA_ROCKET_GLIBC or ANACONDA_ROCKET_GLIBC == "2.17")]
   - 2.26                   # [linux and aarch64 and (not ANACONDA_ROCKET_GLIBC or ANACONDA_ROCKET_GLIBC == "2.26")]
   - 2.28                   # [linux and ANACONDA_ROCKET_GLIBC == "2.28"]
+  - 10.15                  # [osx and x86_64]
+  - 11.1                   # [osx and arm64]
 cxx_compiler_version:      # [linux or osx]
   - 11.2.0                 # [linux]
   - 14                     # [osx]
@@ -86,15 +86,6 @@ cgo_compiler:
   - go-cgo
 cgo_compiler_version:
   - 1.21
-macos_min_version:
-  - 10.15 # [osx and x86_64]
-  - 11.1  # [osx and arm64]
-macos_machine:
-  - x86_64-apple-darwin13.4.0  # [osx and x86_64]
-  - arm64-apple-darwin20.0.0   # [osx and arm64]
-MACOSX_DEPLOYMENT_TARGET:
-  - 10.15 # [osx and x86_64]
-  - 11.1  # [osx and arm64]
 python:
   - 3.9
   - "3.10"
@@ -147,6 +138,21 @@ cdt_name:          # [linux]
 # https://github.com/conda/conda-build/issues/5733
 BUILD: x86_64-conda_el8-linux-gnu   # [linux and x86_64 and ANACONDA_ROCKET_GLIBC == "2.28"]
 BUILD: aarch64-conda_el8-linux-gnu  # [linux and aarch64 and ANACONDA_ROCKET_GLIBC == "2.28"]
+
+# TODO: These are only necessary as we transition to using the stdlib('c') macro. They should be
+# removed once it is safe to do so.
+OSX_SDK_DIR:
+  - /opt                                      # [osx and x86_64]
+  - /Library/Developer/CommandLineTools/SDKs  # [osx and arm64]
+macos_min_version:
+  - 10.15 # [osx and x86_64]
+  - 11.1  # [osx and arm64]
+macos_machine:
+  - x86_64-apple-darwin13.4.0  # [osx and x86_64]
+  - arm64-apple-darwin20.0.0   # [osx and arm64]
+MACOSX_DEPLOYMENT_TARGET:
+  - 10.15 # [osx and x86_64]
+  - 11.1  # [osx and arm64]
 
 ## GLOBAL pinnings
 alsa_lib:


### PR DESCRIPTION
[PKG-8364](https://anaconda.atlassian.net/browse/PKG-8364)

- Relevant dependency PRs:
  - AnacondaRecipes/osx-sysroot-feedstock#1

### Explanation of changes:

- Added values for the OSX sysroot metapackage
- Removed OSX variables that are now exported in the OSX sysroot activation script


[PKG-8364]: https://anaconda.atlassian.net/browse/PKG-8364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ