### PR TITLE
add py314 support

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -94,6 +94,7 @@ python:
   - "3.11"
   - "3.12"
   - "3.13"
+  - "3.14"                 # [ANACONDA_ROCKET_ENABLE_PY314]
 # numpy will by default use a compatible ABI for the oldest still-supported numpy versions
 # `{{ pin_compatible("numpy") }}` is no longer needed as builds of numpy from version 2 have run_exports.
 numpy:
@@ -107,6 +108,8 @@ numpy:
   - 2.0
   # python 3.13
   - 2.1
+  # python 3.14            # [ANACONDA_ROCKET_ENABLE_PY314]
+  - 2.3                    # [ANACONDA_ROCKET_ENABLE_PY314]
 zip_keys:
   -
     - python


### PR DESCRIPTION

### Explanation of changes:

- add conditional support for `py314`
  - `numpy 2.3` support for 3.14 is declared [here](https://numpy.org/news/)
