### PR TITLE
Updating cbc for Boost 1.88.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -219,9 +219,7 @@ backtrace:
 blosc:
   - '1'
 boost:
-  - 1.82
-boost_cpp:
-  - 1.82
+  - 1.88.0
 brotli:
   - '1'
 brunsli:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -218,7 +218,9 @@ backtrace:
   - '20241216'
 blosc:
   - '1'
-boost:
+libboost:
+  - 1.88.0
+libboost-devel:
   - 1.88.0
 brotli:
   - '1'


### PR DESCRIPTION
Updating `boost` to liboost- and `liboost-devel` dependency and removing deprecated package, `boost-cpp`
