### PR TITLE
liboost-devel 1.88.0 to libboost_devel 1.88.0 Syntax Amendment

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -220,7 +220,7 @@ blosc:
   - '1'
 libboost:
   - 1.88.0
-libboost-devel:
+libboost_devel:
   - 1.88.0
 brotli:
   - '1'


### PR DESCRIPTION
Minor syntax error in which libboost must be called as libboost_devel 1.88.0 rather than liboost-devel