### PR TITLE
unpin pybind11_abi

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -717,8 +717,6 @@ pugixml:
   - '1.11'
 py_lief:
   - '0.16'
-pybind11_abi:
-  - '5'
 pyqt:
   - '6.7'
 pyqtchart:


### PR DESCRIPTION
unpin pybind11_abi - pybind11 itself has a constraint on pybind11_abi, which takes different versions based on the architecture and python version. Pinning pybind11_abi goes against this.