### PR TITLE
Windows: openblas and flang

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -128,11 +128,11 @@ r_implementation:
 #    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32
 #    code on win-64 miniconda.
 cross_compiler_target_platform:
-  # - win-32                     # [win]
-  - win-64                     # [win]
+  - win-64                     # [win and x86_64]
+  - win-arm64                  # [win and arm64]
 target_platform:
-  - win-64                     # [win]
-  # - win-32                     # [win]
+  - win-64                     # [win and x86_64]
+  - win-arm64                  # [win and arm64]
 channel_targets:
   - defaults
 cdt_name:          # [linux]

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -7,7 +7,7 @@ pin_run_as_build:
 
 blas_impl:
   - mkl                        # [(x86 or x86_64) and not osx]
-  - openblas                   # [not win]
+  - openblas
 c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
@@ -24,7 +24,7 @@ cuda_compiler:
   - cuda-nvcc
 fortran_compiler:
   - gfortran                   # [linux or osx]
-  - intel-fortran              # [win]
+  - flang                      # [win]
 m2w64_c_compiler:              # [win]
   - m2w64-toolchain            # [win]
 m2w64_cxx_compiler:            # [win]
@@ -70,8 +70,8 @@ cxx_compiler_version:      # [linux or osx]
 cuda_compiler_version:
   - 12.4
 fortran_compiler_version:
-  - 2022.1.0                     # [win]
-  - 14.3.0                       # [osx or linux]
+  - 20                     # [win]
+  - 14.3.0                 # [osx or linux]
 clang_variant:
   - clang
 # The basic go-compiler with CGO disabled (CGO_ENABLED=0).

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -31,29 +31,29 @@ cxx_compiler:
 cxx_compiler_version:          # [linux or osx]
   - 14.3.0                     # [linux]
   - 20                         # [osx]
-cuda_compiler:                 # [linux or win]
-  - cuda-nvcc                  # [linux or win]
-cuda_compiler_version:         # [linux or win]
-  - 12.9                       # [linux or win]
-  - 13.0                       # [linux or win]
+cuda_compiler:                 # [linux or (win and x86_64)]
+  - cuda-nvcc                  # [linux or (win and x86_64)]
+cuda_compiler_version:         # [linux or (win and x86_64)]
+  - 12.9                       # [linux or (win and x86_64)]
+  - 13.0                       # [linux or (win and x86_64)]
 fortran_compiler:
   - gfortran                   # [linux or osx]
   - flang                      # [win]
 fortran_compiler_version:
   - 20                         # [win]
   - 14.3.0                     # [osx or linux]
-m2w64_c_compiler:              # [win]
-  - m2w64-toolchain            # [win]
-m2w64_cxx_compiler:            # [win]
-  - m2w64-toolchain            # [win]
-m2w64_fortran_compiler:        # [win]
-  - m2w64-toolchain            # [win]
-ucrt64_c_compiler:             # [win]
-  - ucrt64-gcc-toolchain       # [win]
-ucrt64_cxx_compiler:           # [win]
-  - ucrt64-gcc-toolchain       # [win]
-ucrt64_fortran_compiler:       # [win]
-  - ucrt64-gcc-toolchain       # [win]
+m2w64_c_compiler:              # [win and x86_64]
+  - m2w64-toolchain            # [win and x86_64]
+m2w64_cxx_compiler:            # [win and x86_64]
+  - m2w64-toolchain            # [win and x86_64]
+m2w64_fortran_compiler:        # [win and x86_64]
+  - m2w64-toolchain            # [win and x86_64]
+ucrt64_c_compiler:             # [win and x86_64]
+  - ucrt64-gcc-toolchain       # [win and x86_64]
+ucrt64_cxx_compiler:           # [win and x86_64]
+  - ucrt64-gcc-toolchain       # [win and x86_64]
+ucrt64_fortran_compiler:       # [win and x86_64]
+  - ucrt64-gcc-toolchain       # [win and x86_64]
 rust_compiler:
   - rust
 rust_compiler_version:
@@ -63,10 +63,10 @@ rust_nightly_compiler:
 rust_nightly_compiler_version:
   - 1.92.0_2025-10-13
 # use {{ compiler('rust-gnu') }} when requiring a build using the m2w64-toolchain
-rust_gnu_compiler:             # [win]
-  - rust-gnu                   # [win]
-rust_gnu_compiler_version:     # [win]
-  - 1.93.1                     # [win]
+rust_gnu_compiler:             # [win and x86_64]
+  - rust-gnu                   # [win and x86_64]
+rust_gnu_compiler_version:     # [win and x86_64]
+  - 1.93.1                     # [win and x86_64]
 VERBOSE_AT:
   - V=1
 VERBOSE_CM:
@@ -128,13 +128,7 @@ r_version:
   - 4.3.1
 r_implementation:
   - 'r-base'    # [linux and x86_64]
-# This differs from target_platform in that it determines what subdir the compiler
-#    will target, not what subdir the compiler package will be itself.
-#    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32
-#    code on win-64 miniconda.
-cross_compiler_target_platform:
-  - win-64                     # [win and x86_64]
-  - win-arm64                  # [win and arm64]
+
 target_platform:
   - win-64                     # [win and x86_64]
   - win-arm64                  # [win and arm64]


### PR DESCRIPTION
### Explanation of changes:

- Switches to flang v20 as default fortran compiler on windows
- Enable openblas as a blas_impl on windows
- Adds win-arm64 target

I've tested this with:
- https://github.com/AnacondaRecipes/numpy-feedstock/pull/135
- https://github.com/AnacondaRecipes/numpy-feedstock/pull/136
- https://github.com/AnacondaRecipes/numpy-feedstock/pull/134
- https://github.com/AnacondaRecipes/numpy-feedstock/pull/133/ 
- https://github.com/AnacondaRecipes/scipy-feedstock/pull/56
- https://github.com/AnacondaRecipes/numexpr-feedstock/pull/16
- https://github.com/AnacondaRecipes/suitesparse-feedstock/pull/6
- https://github.com/AnacondaRecipes/dsdp-feedstock/pull/6
- https://github.com/AnacondaRecipes/cvxopt-feedstock/pull/13
- https://github.com/AnacondaRecipes/igraph-feedstock/pull/5
- https://github.com/AnacondaRecipes/arpack-feedstock/pull/5
- https://github.com/AnacondaRecipes/scs-feedstock/pull/7
- and more see: https://anaconda.atlassian.net/browse/PKG-6188