### PR TITLE
refresh cbc - update cuda compiler version

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -12,19 +12,35 @@ c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
   - vs2022                     # [win]
+c_compiler_version:            # [linux or osx]
+  - 14.3.0                     # [linux]
+  - 20                         # [osx]
 c_stdlib:
   - sysroot                    # [linux]
   - macosx_deployment_target   # [osx]
   - vs                         # [win]
+c_stdlib_version:
+  - 2.28                       # [linux]
+  - 10.15                      # [osx and x86_64]
+  - 12.1                       # [osx and arm64]
+  - 2022.14                    # [win]
 cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]
   - vs2022                     # [win]
+cxx_compiler_version:          # [linux or osx]
+  - 14.3.0                     # [linux]
+  - 20                         # [osx]
 cuda_compiler:
   - cuda-nvcc
+cuda_compiler_version:
+  - 12.4
 fortran_compiler:
   - gfortran                   # [linux or osx]
   - intel-fortran              # [win]
+fortran_compiler_version:
+  - 2022.1.0                   # [win]
+  - 14.3.0                     # [osx or linux]
 m2w64_c_compiler:              # [win]
   - m2w64-toolchain            # [win]
 m2w64_cxx_compiler:            # [win]
@@ -39,10 +55,10 @@ ucrt64_fortran_compiler:       # [win]
   - ucrt64-gcc-toolchain       # [win]
 rust_compiler:
   - rust
-rust_nightly_compiler:
-  - rust-nightly
 rust_compiler_version:
   - 1.93.1
+rust_nightly_compiler:
+  - rust-nightly
 rust_nightly_compiler_version:
   - 1.92.0_2025-10-13
 # use {{ compiler('rust-gnu') }} when requiring a build using the m2w64-toolchain
@@ -56,22 +72,6 @@ VERBOSE_CM:
   - VERBOSE=1
 cran_mirror:
   - https://cran.r-project.org
-c_compiler_version:        # [linux or osx]
-  - 14.3.0                 # [linux]
-  - 20                     # [osx]
-c_stdlib_version:
-  - 2.28                   # [linux]
-  - 10.15                  # [osx and x86_64]
-  - 12.1                   # [osx and arm64]
-  - 2022.14                # [win]
-cxx_compiler_version:      # [linux or osx]
-  - 14.3.0                 # [linux]
-  - 20                     # [osx]
-cuda_compiler_version:
-  - 12.4
-fortran_compiler_version:
-  - 2022.1.0                     # [win]
-  - 14.3.0                       # [osx or linux]
 clang_variant:
   - clang
 # The basic go-compiler with CGO disabled (CGO_ENABLED=0).
@@ -137,11 +137,6 @@ channel_targets:
   - defaults
 cdt_name:          # [linux]
   - el8            # [linux]
-
-# https://github.com/conda/conda-build/issues/5733
-BUILD:                           # [linux]
-  - x86_64-conda_el8-linux-gnu   # [linux and x86_64]
-  - aarch64-conda_el8-linux-gnu  # [linux and aarch64]
 
 OSX_SDK_DIR:                                  # [osx]
   - /opt                                      # [osx and x86_64]

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -31,10 +31,11 @@ cxx_compiler:
 cxx_compiler_version:          # [linux or osx]
   - 14.3.0                     # [linux]
   - 20                         # [osx]
-cuda_compiler:
-  - cuda-nvcc
-cuda_compiler_version:
-  - 12.4
+cuda_compiler:                 # [linux or win]
+  - cuda-nvcc                  # [linux or win]
+cuda_compiler_version:         # [linux or win]
+  - 12.9                       # [linux or win]
+  - 13.1                       # [linux or win]
 fortran_compiler:
   - gfortran                   # [linux or osx]
   - intel-fortran              # [win]

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -35,7 +35,7 @@ cuda_compiler:                 # [linux or win]
   - cuda-nvcc                  # [linux or win]
 cuda_compiler_version:         # [linux or win]
   - 12.9                       # [linux or win]
-  - 13.1                       # [linux or win]
+  - 13.0                       # [linux or win]
 fortran_compiler:
   - gfortran                   # [linux or osx]
   - intel-fortran              # [win]

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -319,6 +319,8 @@ glfw:
   - '3'
 glib:
   - '2'
+glog:
+  - '0.7'
 glpk:
   - '4.65'
 glslang:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -163,8 +163,6 @@ MACOSX_DEPLOYMENT_TARGET:
   - 12.1  # [osx and arm64]
 
 ## GLOBAL pinnings
-abseil_cpp:
-  - '20230802.0'
 alsa_lib:
   - '1.2'
 ampl_mp:
@@ -259,24 +257,8 @@ coin_or_utils:
   - '2.11'
 cryptography_vectors:
   - 46.0.7
-cuda_cudart:
-  - '13'
-cuda_cupti:
-  - '13'
-cuda_nvrtc:
-  - '13'
-cuda_nvtx:
-  - '13'
-cuda_opencl:
-  - '13'
-cudnn:
-  - '9'
-cusparselt:
-  - 0.9.0
-cutensor:
-  - '2'
 cyrus_sasl:
-  - 2.1.28
+  - '2'
 dal:
   - '2023'
 dav1d:
@@ -314,9 +296,7 @@ freetype:
 freexl:
   - '2'
 fribidi:
-  - '1'
-g2clib:
-  - '1.6'
+  - '1.0'
 gcab:
   - '1'
 gdbm:
@@ -343,14 +323,12 @@ glfw:
   - '3'
 glib:
   - '2'
-glog:
-  - '0.5'
 glpk:
   - '4.65'
 glslang:
   - '15'
 gmp:
-  - 6.3.0
+  - '6'
 gnupg:
   - '2.4'
 gnutls:
@@ -381,10 +359,6 @@ hdf4:
   - 4.2.13
 hdf5:
   - 2.0.0
-hdfeos2:
-  - 2.20
-hdfeos5:
-  - 5.1
 hidapi:
   - '0.8'
 icc_rt:
@@ -441,8 +415,6 @@ lcms2:
   - '2'
 leptonica:
   - '1.82'
-lerc:
-  - '4'
 level_zero:
   - '1'
 leveldb:
@@ -472,9 +444,9 @@ libassuan:
 libavif:
   - '1'
 libboost:
-  - 1.88.0
+  - '1.88'
 libboost_devel:
-  - 1.88.0
+  - '1.88'
 libboost_python:
   - '1.88'
 libbrotlicommon:
@@ -507,30 +479,10 @@ libcrc32c:
   - '1.1'
 libcryptominisat:
   - '5.12'
-libcublas:
-  - '13'
-libcudnn:
-  - '9'
-libcudnn_jit:
-  - '9'
-libcufft:
-  - '12'
-libcufile:
-  - '1'
-libcuobjclient:
-  - '1'
 libcups:
   - '2.4'
-libcurand:
-  - '10'
 libcurl:
   - '8'
-libcusolver:
-  - '12'
-libcusparse:
-  - '12'
-libdap4:
-  - '3.19'
 libde265:
   - 1.0.15
 libdeflate:
@@ -554,11 +506,9 @@ libfaiss:
 libfaiss_avx2:
   - 1.14.1
 libffi:
-  - '3.4'
+  - '3'
 libflac:
   - '1.5'
-libflang:
-  - 20.1.8
 libflang_rt:
   - 22.1.2
 libgcrypt:
@@ -665,24 +615,12 @@ libnghttp2:
   - '1.68'
 libnl:
   - '3'
-libnpp:
-  - '13'
 libnsl:
   - '2.0'
 libntlm:
   - '1'
 libnuma:
   - '2'
-libnvcomp:
-  - '5'
-libnvfatbin:
-  - '13'
-libnvjitlink:
-  - '13'
-libnvjpeg:
-  - '13'
-libnvshmem3:
-  - 3.5.21
 libogg:
   - '1.3'
 libopenblas:
@@ -699,8 +637,6 @@ libortools:
   - '9.15'
 libosqp:
   - 1.0.0
-libpcap:
-  - '1.10'
 libpciaccess:
   - '0.18'
 libpng:
@@ -733,10 +669,6 @@ libssh2:
   - '1'
 libtasn1:
   - '4'
-libtensorflow:
-  - 2.18.1
-libtensorflow_cc:
-  - 2.18.1
 libtheora:
   - '1.2'
 libthrift:
@@ -767,8 +699,6 @@ libvpl:
   - '2.15'
 libvpx:
   - '1.16'
-libvulkan:
-  - 1.4
 libwebp:
   - '1'
 libwebp_base:
@@ -793,8 +723,6 @@ libzlib_wapi:
   - '1'
 libzopfli:
   - '1.0'
-llvm_openmp:
-  - 22.1.2
 lmdb:
   - '0'
 lz4_c:
@@ -807,8 +735,6 @@ mbedtls:
   - '3.5'
 mesalib:
   - '25.1'
-metis:
-  - '5.1'
 minizip:
   - '4'
 mkl:
@@ -827,8 +753,6 @@ mpich:
   - '4'
 mysql_libs:
   - '9.3'
-nanobind_abi:
-  - '15'
 nccl:
   - '2'
 ncurses:
@@ -847,8 +771,6 @@ ntbtls:
   - '0'
 ocl_icd:
   - '2'
-oniguruma:
-  - '6.9'
 onnxruntime_cpp:
   - 1.24.4
 onnxruntime_novec_cpp:
@@ -881,8 +803,6 @@ pcre2:
   - '10.46'
 pdal:
   - '2.5'
-perl:
-  - 5.42
 perl_class_inspector:
   - '1.36'
 perl_exporter:
@@ -894,13 +814,11 @@ perl_file_sharedir:
 perl_file_sharedir_install:
   - '0.14'
 pixman:
-  - 0.46.4
+  - '0'
 popt:
   - '1'
 proj:
   - 9.7.1
-ptscotch:
-  - 6.0.9
 pugixml:
   - '1.11'
 pulseaudio_client:
@@ -966,17 +884,15 @@ re2:
 readline:
   - '8'
 reproc:
-  - '14.2'
+  - '14'
 reproc_cpp:
-  - '14.2'
+  - '14'
 rhash:
   - '1'
 ruby:
   - '3.4'
 s2n:
   - 1.6.2
-scotch:
-  - 6.0.9
 serf:
   - '1.3'
 shaderc:
@@ -1019,14 +935,12 @@ unixodbc:
   - '2.3'
 util_linux:
   - '2.39'
-vc:
-  - '14'
 vtk_base:
   - 9.5.2
 vtk_io_ffmpeg:
   - 9.5.2
 wayland:
-  - '1.24'
+  - '1'
 x264:
   - 1!157.20191217
 xcb_util:


### PR DESCRIPTION
Following https://github.com/anaconda/aggregate-duct-tape/pull/38

- Reorder global section (move compiler versions next to the corresponding compilers)
- Update cuda compiler version from 12.4 to 12.9 and ~~13.1~~ 13.0
- Remove BUILD workaround (addressed in conda-build 25.11.0 https://github.com/conda/conda-build/issues/5733)
- Remove inactive projects from pins, or projects that are pinning exceptions: https://github.com/anaconda/aggregate-duct-tape/blob/main/scripts/update_aggregate_conda_build_config.py#L120
- Remove cuda related package pins (example: cuda_cudart). These packages depend on cuda-version, which effectively handles which versions to pull depending on the cuda compiler used.