### PR TITLE
Update conda_build_config.yaml pinnings

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -678,7 +678,7 @@ libtirpc:
 libtmglib:
   - '3'
 libtorch:
-  - '2.9'
+  - '2.10'
 libunistring:
   - '1'
 libunwind:
@@ -836,7 +836,7 @@ pyqtwebengine:
 python_igraph:
   - '1.0'
 pytorch:
-  - '2.9'
+  - '2.10'
 qhull:
   - '2020.2'
 qpdf:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/24669692247)

Compatibility reports are available at https://anaconda.github.io/distro-compatibility-report