### PR TITLE
pin perl and lua

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -118,6 +118,8 @@ python_implementation:
   - cpython
 python_impl:
   - cpython
+perl:
+  - '5'
 r_base:
   - 4.3.1
 r_version:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -120,6 +120,8 @@ python_impl:
   - cpython
 perl:
   - '5'
+lua:
+  - '5'
 r_base:
   - 4.3.1
 r_version:


### PR DESCRIPTION
perl and lua have default pins set by conda-build that may not match versions available on the main channel.

Setting these pins to be compatible with main.