### PR TITLE
Update conda_build_config.yaml pinnings

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -180,21 +180,21 @@ attr:
 av:
   - '16'
 aws_c_auth:
-  - 0.9.4
+  - 0.10.1
 aws_c_cal:
   - 0.9.13
 aws_c_common:
   - 0.12.6
 aws_c_compression:
-  - 0.3.1
+  - 0.3.2
 aws_c_event_stream:
-  - 0.6.0
+  - 0.6.1
 aws_c_http:
-  - 0.10.7
+  - 0.10.13
 aws_c_io:
-  - 0.23.3
+  - 0.26.3
 aws_c_mqtt:
-  - 0.13.3
+  - 0.15.2
 aws_c_s3:
   - 0.12.0
 aws_c_sdkutils:
@@ -326,7 +326,7 @@ glslang:
 gmp:
   - '6'
 gnupg:
-  - '2.4'
+  - '2.5'
 gnutls:
   - '3.8'
 graphite2:
@@ -411,6 +411,8 @@ lcms2:
   - '2'
 leptonica:
   - '1.82'
+lerc:
+  - '4.1'
 level_zero:
   - '1'
 leveldb:
@@ -452,7 +454,7 @@ libbrotlidec:
 libbrotlienc:
   - '1.2'
 libcap:
-  - '2.77'
+  - '2.78'
 libclang13:
   - 22.1.2
 libclang_cpp10:
@@ -708,7 +710,7 @@ libxkbcommon:
 libxkbfile:
   - '1'
 libxml2:
-  - '2.13'
+  - '2.14'
 libxmlsec1:
   - '1.3'
 libxslt:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -710,7 +710,7 @@ libxkbcommon:
 libxkbfile:
   - '1'
 libxml2:
-  - '2.14'
+  - '2.13'
 libxmlsec1:
   - '1.3'
 libxslt:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/24998350156)

Compatibility reports are available at https://anaconda.github.io/distro-compatibility-report