### PR TITLE
Update conda_build_config.yaml pinnings

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -710,7 +710,7 @@ libxkbcommon:
 libxkbfile:
   - '1'
 libxml2:
-  - '2.14'
+  - '2.13'
 libxmlsec1:
   - '1.3'
 libxslt:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -482,7 +482,7 @@ libcups:
 libcurl:
   - '8'
 libde265:
-  - 1.0.15
+  - 1.0.18
 libdeflate:
   - '1.22'
 libdrm:
@@ -504,7 +504,7 @@ libfaiss:
 libfaiss_avx2:
   - 1.14.1
 libffi:
-  - '3'
+  - '3.4'
 libflac:
   - '1.5'
 libflang_rt:
@@ -610,7 +610,7 @@ libmpdecxx:
 libnetcdf:
   - '4'
 libnghttp2:
-  - '1.68'
+  - '1.69'
 libnl:
   - '3'
 libnsl:
@@ -710,7 +710,7 @@ libxkbcommon:
 libxkbfile:
   - '1'
 libxml2:
-  - '2.13'
+  - '2.14'
 libxmlsec1:
   - '1.3'
 libxslt:
@@ -730,7 +730,7 @@ lzo:
 macports_legacy_support:
   - '1'
 mbedtls:
-  - '3.5'
+  - '4.1'
 mesalib:
   - '25.1'
 minizip:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/25112229335)

Compatibility reports are available at https://anaconda.github.io/distro-compatibility-report