### PR TITLE
Update conda_build_config.yaml pinnings

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -360,7 +360,7 @@ hidapi:
 icc_rt:
   - 2022.1.0
 icu:
-  - '73'
+  - '78'
 igraph:
   - '1.0'
 intel_cmplr_lib_rt:
@@ -388,9 +388,9 @@ jasper:
 jbig2dec:
   - '0.20'
 jemalloc:
-  - 5.3.0
+  - 5.3.1
 jemalloc_local:
-  - 5.3.0
+  - 5.3.1
 jpeg:
   - 9f
 json_c:
@@ -514,9 +514,9 @@ libgcrypt:
 libgd:
   - '2.3'
 libgdal:
-  - '3.11'
+  - '3.12'
 libgdal_core:
-  - '3.11'
+  - '3.12'
 libgettextpo:
   - '0'
 libgit2:
@@ -678,7 +678,7 @@ libtirpc:
 libtmglib:
   - '3'
 libtorch:
-  - '2.10'
+  - '2.11'
 libunistring:
   - '1'
 libunwind:
@@ -710,7 +710,7 @@ libxkbcommon:
 libxkbfile:
   - '1'
 libxml2:
-  - '2.13'
+  - '2.14'
 libxmlsec1:
   - '1.3'
 libxslt:
@@ -836,7 +836,7 @@ pyqtwebengine:
 python_igraph:
   - '1.0'
 pytorch:
-  - '2.10'
+  - '2.11'
 qhull:
   - '2020.2'
 qpdf:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/25674654355)

Compatibility reports are available at https://anaconda.github.io/distro-compatibility-report