### PR TITLE
Update conda_build_config.yaml pinnings

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -520,7 +520,7 @@ libgdal_core:
 libgettextpo:
   - '0'
 libgit2:
-  - '1.6'
+  - '1.9'
 libgl:
   - '1'
 libgles:
@@ -934,9 +934,9 @@ unixodbc:
 util_linux:
   - '2.39'
 vtk_base:
-  - 9.5.2
+  - 9.6.1
 vtk_io_ffmpeg:
-  - 9.5.2
+  - 9.6.1
 vulkan_loader:
   - '1.4'
 wayland:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/25863251277)

Compatibility reports are available at https://anaconda.github.io/distro-compatibility-report