### PR TITLE
Update conda_build_config.yaml pinnings

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -896,7 +896,7 @@ serf:
 shaderc:
   - '2025.5'
 simdjson:
-  - '3.10'
+  - '4.6'
 sip:
   - '6.15'
 sleef:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/26453071280)

Compatibility reports are available at https://anaconda.github.io/distro-compatibility-report