### PR TITLE
Update conda_build_config.yaml pinnings

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -644,7 +644,7 @@ libpq:
 libprotobuf:
   - 6.33.5
 libqdldl:
-  - 0.1.8
+  - 0.1.9
 librdkafka:
   - '2.2'
 libre2_11:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/26641998524)

Compatibility reports are available at https://anaconda.github.io/distro-compatibility-report