### PR TITLE
torchao-feedstock: adding new submodule (PKG-14920)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12749,3 +12749,6 @@
 	path = pyglfw-feedstock
 	url = ../pyglfw-feedstock
 	branch = main
+[submodule "torchao-feedstock"]
+	path = torchao-feedstock
+	url = git@github.com-anaconda:AnacondaRecipes/torchao-feedstock.git


### PR DESCRIPTION
torchao-feedstock: adding new submodule (PKG-14920)

**Destination channel:** defaults

### Links

- [PKG-14920](https://anaconda.atlassian.net/browse/PKG-14920)
- [torchao-feedstock PR #1](https://github.com/AnacondaRecipes/torchao-feedstock/pull/1)

### Explanation of changes:

- Adds `torchao-feedstock` as a new submodule
- Feedstock PR: https://github.com/AnacondaRecipes/torchao-feedstock/pull/1

[PKG-14920]: https://anaconda.atlassian.net/browse/PKG-14920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ