### PR TITLE
libnvpl-feedstock: adding new submodule (PKG-15071)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12849,3 +12849,7 @@
 	path = libgsasl-feedstock
 	url = ../libgsasl-feedstock
 	branch = master
+[submodule "libnvpl-feedstock"]
+	path = libnvpl-feedstock
+	url = ../libnvpl-feedstock
+	branch = main


### PR DESCRIPTION
libnvpl-feedstock: adding new submodule

**Destination channel:** defaults

### Links

- [PKG-15071](https://anaconda.atlassian.net/browse/PKG-15071)
- Feedstock PR: https://github.com/AnacondaRecipes/libnvpl-feedstock/pull/1

### Explanation of changes:

- Adds the new `libnvpl-feedstock` submodule (fork of conda-forge/libnvpl-feedstock), part of the NVPL / nvidia-channel-sunset effort. First package of the NVPL chain: ships `_nvpl_dev_mutex`, which every `libnvpl-*-dev` component package depends on.

[PKG-15071]: https://anaconda.atlassian.net/browse/PKG-15071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ