### PR TITLE
Update conda_build_config.yaml pinnings

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -180,7 +180,7 @@ attr:
 av:
   - '16'
 aws_c_auth:
-  - 0.10.1
+  - 0.10.3
 aws_c_cal:
   - 0.9.14
 aws_c_common:
@@ -196,15 +196,15 @@ aws_c_io:
 aws_c_mqtt:
   - 0.15.2
 aws_c_s3:
-  - 0.12.0
+  - 0.12.5
 aws_c_sdkutils:
   - 0.2.4
 aws_checksums:
   - 0.2.10
 aws_crt_cpp:
-  - 0.37.4
+  - 0.40.1
 aws_sdk_cpp:
-  - 1.11.774
+  - 1.11.826
 azure_core_cpp:
   - 1.16.1
 azure_identity_cpp:
@@ -250,7 +250,7 @@ coin_or_osi:
 coin_or_utils:
   - '2.11'
 cryptography_vectors:
-  - 48.0.0
+  - 49.0.0
 cyrus_sasl:
   - '2'
 dal:
@@ -936,9 +936,9 @@ util_linux:
 vcomp14:
   - 14.44.35208
 vtk_base:
-  - 9.6.1
+  - 9.6.2
 vtk_io_ffmpeg:
-  - 9.6.1
+  - 9.6.2
 vulkan_loader:
   - '1.4'
 wayland:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/27623201608)

Compatibility reports are available at https://anaconda.github.io/distro-compatibility-report