### PR TITLE
Update conda_build_config.yaml pinnings

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -589,6 +589,8 @@ libmamba:
   - '2.3'
 libmambapy:
   - '2.3'
+libmathdx0:
+  - 0.3.1
 libmklml:
   - 2019.0.5
 libmlir12:
@@ -694,7 +696,7 @@ libva:
 libvorbis:
   - '1'
 libvpl:
-  - '2.15'
+  - '2.16'
 libvpx:
   - '1.16'
 libwebp:
@@ -920,7 +922,7 @@ svt_av1:
 tbb:
   - 2023.0.0
 tesseract:
-  - 5.2.0
+  - 5.5.2
 tiledb:
   - '2.30'
 tk:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/28174689304)

Compatibility reports are available at https://anaconda.github.io/distro-compatibility-report