### PR TITLE
Update pin for libmathdx0 0.3.1

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -589,6 +589,8 @@ libmamba:
   - '2.3'
 libmambapy:
   - '2.3'
+libmathdx0:
+  - 0.3.1
 libmklml:
   - 2019.0.5
 libmlir12:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/28255761096)

libmathdx0 updated to 0.3.1

Explore required actions on depends of libmathdx0 by calling:
```
pbc migration identify distro-db libmathdx0:0.3.1
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
