### PR TITLE
Update pin for libvpl 2.16

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -694,7 +694,7 @@ libva:
 libvorbis:
   - '1'
 libvpl:
-  - '2.15'
+  - '2.16'
 libvpx:
   - '1.16'
 libwebp:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/28255761096)

libvpl updated to 2.16

Explore required actions on depends of libvpl by calling:
```
pbc migration identify distro-db libvpl:2.16
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
