### PR TITLE
Update pin for tesseract 5.5.2

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -920,7 +920,7 @@ svt_av1:
 tbb:
   - 2023.0.0
 tesseract:
-  - 5.2.0
+  - 5.5.2
 tiledb:
   - '2.30'
 tk:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/28255761096)

tesseract updated to 5.5.2

Explore required actions on depends of tesseract by calling:
```
pbc migration identify distro-db tesseract:5.5.2
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
