### PR TITLE
Update pin for libopensubdiv 3.7.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -637,6 +637,8 @@ libopengl:
   - '1'
 libopenjpeg:
   - '2.5'
+libopensubdiv:
+  - 3.7.0
 libopus:
   - '1'
 libortools:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/28572090655)

libopensubdiv updated to 3.7.0

Explore required actions on depends of libopensubdiv by calling:
```
pbc migration identify distro-db libopensubdiv:3.7.0
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
