### PR TITLE
Update pin for libevent 2.1.13

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -502,7 +502,7 @@ libegl:
 libev:
   - '4.33'
 libevent:
-  - 2.1.12
+  - 2.1.13
 libexpat:
   - '2'
 libfaiss:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/28677518477)

libevent updated to 2.1.13

Explore required actions on depends of libevent by calling:
```
pbc migration identify distro-db libevent:2.1.13
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
