### PR TITLE
Update pin for mysql_libs 9.7

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -760,7 +760,7 @@ mpg123:
 mpich:
   - '4'
 mysql_libs:
-  - '9.3'
+  - '9.7'
 nccl:
   - '2'
 ncurses:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/28890074260)

mysql_libs updated to 9.7

Explore required actions on depends of mysql_libs by calling:
```
pbc migration identify distro-db mysql_libs:9.7
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
