### PR TITLE
Update pin for libthrift 0.23

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -680,7 +680,7 @@ libtasn1:
 libtheora:
   - '1.2'
 libthrift:
-  - '0.22'
+  - '0.23'
 libtiff:
   - '4'
 libtirpc:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/28966312452)

libthrift updated to 0.23

Explore required actions on depends of libthrift by calling:
```
pbc migration identify distro-db libthrift:0.23
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
