### PR TITLE
Update pin for arrow_cpp 24.0.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -174,7 +174,7 @@ armadillo:
 arpack:
   - '3.9'
 arrow_cpp:
-  - 23.0.1
+  - 24.0.0
 assimp:
   - 6.0.2
 at_spi2_core:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/29163205221)

arrow_cpp updated to 24.0.0

Explore required actions on depends of arrow_cpp by calling:
```
pbc migration identify distro-db arrow_cpp:24.0.0
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
