### PR TITLE
Add anaconda-env-log-feedstock submodule (PKG-15616)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12905,3 +12905,8 @@
 	path = scikit-network-feedstock
 	url = ../scikit-network-feedstock
 	branch = main
+
+[submodule "anaconda-env-log-feedstock"]
+	path = anaconda-env-log-feedstock
+	url = ../anaconda-env-log-feedstock
+	branch = main


### PR DESCRIPTION
## Summary
- Add `anaconda-env-log-feedstock` as a new aggregate submodule for [PKG-15616](https://anaconda.atlassian.net/browse/PKG-15616)
- Points at current feedstock tip (`a849018` on `add-recipe`); tracking branch set to `main`

## Links
- Feedstock PR: https://github.com/AnacondaRecipes/anaconda-env-log-feedstock/pull/1
- Jira: https://anaconda.atlassian.net/browse/PKG-15616


Made with [Cursor](https://cursor.com)

[PKG-15616]: https://anaconda.atlassian.net/browse/PKG-15616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ