### PR TITLE
Update pin for libxml2 2.15

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -720,7 +720,7 @@ libxkbcommon:
 libxkbfile:
   - '1'
 libxml2:
-  - '2.14'
+  - '2.15'
 libxmlsec1:
   - '1.3'
 libxslt:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/29461538792)

libxml2 updated to 2.15

Explore required actions on depends of libxml2 by calling:
```
pbc migration identify distro-db libxml2:2.15
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
