### PR TITLE
Update pin for at_spi2_core 2.61

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -178,7 +178,7 @@ arrow_cpp:
 assimp:
   - 6.0.2
 at_spi2_core:
-  - '2.36'
+  - '2.61'
 atk_1_0:
   - 2.38.0
 attr:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/29655609443)

at_spi2_core updated to 2.61

Explore required actions on depends of at_spi2_core by calling:
```
pbc migration identify distro-db at_spi2_core:2.61
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
