### PR TITLE
Update pin for capnproto 1.5.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -238,7 +238,7 @@ c_blosc2:
 cairo:
   - '1'
 capnproto:
-  - 1.1.0
+  - 1.5.0
 ceres_solver:
   - '2.2'
 cfitsio:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/29655609443)

capnproto updated to 1.5.0

Explore required actions on depends of capnproto by calling:
```
pbc migration identify distro-db capnproto:1.5.0
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
