### PR TITLE
Update pin for json_c 0.19

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -400,7 +400,7 @@ jemalloc_local:
 jpeg:
   - 9f
 json_c:
-  - '0.18'
+  - '0.19'
 jsoncpp:
   - 1.9.7
 jxrlib:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/29655609443)

json_c updated to 0.19

Explore required actions on depends of json_c by calling:
```
pbc migration identify distro-db json_c:0.19
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
