### PR TITLE
Update pin for libabseil 20260526

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -424,7 +424,7 @@ level_zero:
 leveldb:
   - '1.23'
 libabseil:
-  - '20260107'
+  - '20260526'
 libacl:
   - '2.3'
 libaec:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/29790476743)

libabseil updated to 20260526

Explore required actions on depends of libabseil by calling:
```
pbc migration identify distro-db libabseil:20260526
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
