### PR TITLE
Update pin for gdbm 1.26

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -300,7 +300,7 @@ fribidi:
 gcab:
   - '1'
 gdbm:
-  - '1.18'
+  - '1.26'
 gdk_pixbuf:
   - '2'
 geos:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/29857363238)

gdbm updated to 1.26

Explore required actions on depends of gdbm by calling:
```
pbc migration identify distro-db gdbm:1.26
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
