### PR TITLE
Update pin for libprotobuf 7.35.1

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -652,7 +652,7 @@ libpng:
 libpq:
   - '17'
 libprotobuf:
-  - 6.33.5
+  - 7.35.1
 libqdldl:
   - 0.1.9
 librdkafka:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/29986343828)

libprotobuf updated to 7.35.1

Explore required actions on depends of libprotobuf by calling:
```
pbc migration identify distro-db libprotobuf:7.35.1
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
