### PR TITLE
Update pin for lmdb 1

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -732,7 +732,7 @@ libzlib_wapi:
 libzopfli:
   - '1.0'
 lmdb:
-  - '0'
+  - '1'
 lz4_c:
   - '1.9'
 lzo:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/30033776642)

lmdb updated to 1

Explore required actions on depends of lmdb by calling:
```
pbc migration identify distro-db lmdb:1
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
