### PR TITLE
Update pin for libhwloc 2.14.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -552,7 +552,7 @@ libheif:
 libhiredis:
   - '1.3'
 libhwloc:
-  - 2.13.0
+  - 2.14.0
 libiconv:
   - '1'
 libidn2:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/30136483063)

libhwloc updated to 2.14.0

Explore required actions on depends of libhwloc by calling:
```
pbc migration identify distro-db libhwloc:2.14.0
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
