### PR TITLE
Update pin for isl 0.28

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -384,7 +384,7 @@ intel_opencl_rt:
 intel_sycl_rt:
   - '2025'
 isl:
-  - '0.22'
+  - '0.28'
 jack:
   - '1.9'
 jansson:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/30387674470)

isl updated to 0.28

Explore required actions on depends of isl by calling:
```
pbc migration identify distro-db isl:0.28
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
