### PR TITLE
Update pin for mesalib 26.1

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -742,7 +742,7 @@ macports_legacy_support:
 mbedtls:
   - '4.1'
 mesalib:
-  - '25.1'
+  - '26.1'
 minizip:
   - '4'
 mkl:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/30963463665)

mesalib updated to 26.1

Explore required actions on depends of mesalib by calling:
```
pbc migration identify distro-db mesalib:26.1
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
