### PR TITLE
Update pin for ruby 4.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -898,7 +898,7 @@ reproc_cpp:
 rhash:
   - '1'
 ruby:
-  - '3.4'
+  - '4.0'
 s2n:
   - 1.6.2
 serf:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/30963463665)

ruby updated to 4.0

Explore required actions on depends of ruby by calling:
```
pbc migration identify distro-db ruby:4.0
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
