### PR TITLE
Update pin for libgrpc 1.82

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -542,7 +542,7 @@ libglx:
 libgpg_error:
   - '1'
 libgrpc:
-  - '1.78'
+  - '1.82'
 libgsasl:
   - '1'
 libgsf:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/31177466750)

libgrpc updated to 1.82

Explore required actions on depends of libgrpc by calling:
```
pbc migration identify distro-db libgrpc:1.82
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
