### PR TITLE
Update pin for libpq 18

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -650,7 +650,7 @@ libpciaccess:
 libpng:
   - '1.6'
 libpq:
-  - '17'
+  - '18'
 libprotobuf:
   - 6.33.5
 libqdldl:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/31206196319)

libpq updated to 18

Explore required actions on depends of libpq by calling:
```
pbc migration identify distro-db libpq:18
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
