### PR TITLE
Update pin for libtorch 2.13, pytorch 2.13

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -688,7 +688,7 @@ libtirpc:
 libtmglib:
   - '3'
 libtorch:
-  - '2.12'
+  - '2.13'
 libunistring:
   - '1'
 libunwind:
@@ -846,7 +846,7 @@ pyqtwebengine:
 python_igraph:
   - '1.0'
 pytorch:
-  - '2.12'
+  - '2.13'
 qhull:
   - '2020.2'
 qpdf:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/31285752785)

libtorch updated to 2.13

Explore required actions on depends of libtorch by calling:
```
pbc migration identify distro-db libtorch:2.13
pbc migration export to_image  feedstock_dependencies.yaml
```

pytorch updated to 2.13

Explore required actions on depends of pytorch by calling:
```
pbc migration identify distro-db pytorch:2.13
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
