### PR TITLE
Update pin for qpdf 12

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -850,7 +850,7 @@ pytorch:
 qhull:
   - '2020.2'
 qpdf:
-  - '11'
+  - '12'
 qt:
   - '6.11'
 qt5compat:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/31445422925)

qpdf updated to 12

Explore required actions on depends of qpdf by calling:
```
pbc migration identify distro-db qpdf:12
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
