### PR TITLE
Update pin for libcapstone 5.0.9

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -461,6 +461,8 @@ libbrotlienc:
   - '1.2'
 libcap:
   - '2.78'
+libcapstone:
+  - 5.0.9
 libclang13:
   - 22.1.2
 libclang_cpp10:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/31521952146)

libcapstone updated to 5.0.9

Explore required actions on depends of libcapstone by calling:
```
pbc migration identify distro-db libcapstone:5.0.9
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
