### PR TITLE
Remove fsspec-feedstock added by mistake

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13102,7 +13102,3 @@
 	path = gdstk-feedstock
 	url = ../gdstk-feedstock
 	branch = main
-[submodule "fsspec-feedstock"]
-	path = fsspec-feedstock
-	url = ../fsspec-feedstock
-	branch = main


### PR DESCRIPTION

### Explanation of changes:

Remove fsspec-feedstock from repo, added by mistake.