### PR TITLE
Update pin for tk 9.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -934,7 +934,7 @@ tesseract:
 tiledb:
   - '2.30'
 tk:
-  - '8.6'
+  - '9.0'
 ucc:
   - '1'
 ucx:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/31730099233)

tk updated to 9.0

Explore required actions on depends of tk by calling:
```
pbc migration identify distro-db tk:9.0
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
