### PR TITLE
Update pin for s2n 1.7.7

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -900,7 +900,7 @@ rhash:
 ruby:
   - '3.4'
 s2n:
-  - 1.6.2
+  - 1.7.7
 serf:
   - '1.3'
 shaderc:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/32000577600)

s2n updated to 1.7.7

Explore required actions on depends of s2n by calling:
```
pbc migration identify distro-db s2n:1.7.7
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
