### PR TITLE
Update pin for cryptography_vectors 50.0.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -256,7 +256,7 @@ coin_or_osi:
 coin_or_utils:
   - '2.11'
 cryptography_vectors:
-  - 49.0.0
+  - 50.0.0
 cyrus_sasl:
   - '2'
 dal:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/32316277294)

cryptography_vectors updated to 50.0.0

Explore required actions on depends of cryptography_vectors by calling:
```
pbc migration identify distro-db cryptography_vectors:50.0.0
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
