### PR TITLE
Update pin for libfaiss 1.15.0, libfaiss_avx2 1.15.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -508,9 +508,9 @@ libevent:
 libexpat:
   - '2'
 libfaiss:
-  - 1.14.1
+  - 1.15.0
 libfaiss_avx2:
-  - 1.14.1
+  - 1.15.0
 libffi:
   - '3.4'
 libflac:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/32367263397)

libfaiss updated to 1.15.0

Explore required actions on depends of libfaiss by calling:
```
pbc migration identify distro-db libfaiss:1.15.0
pbc migration export to_image  feedstock_dependencies.yaml
```

libfaiss_avx2 updated to 1.15.0

Explore required actions on depends of libfaiss_avx2 by calling:
```
pbc migration identify distro-db libfaiss_avx2:1.15.0
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
