### PR TITLE
Update pin for libpciaccess 0.19

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -648,7 +648,7 @@ libortools:
 libosqp:
   - 1.0.0
 libpciaccess:
-  - '0.18'
+  - '0.19'
 libpng:
   - '1.6'
 libpq:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/32401494233)

libpciaccess updated to 0.19

Explore required actions on depends of libpciaccess by calling:
```
pbc migration identify distro-db libpciaccess:0.19
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
