### PR TITLE
Update pin for xorg_xorgproto 2025

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1016,7 +1016,7 @@ xorg_libxxf86vm:
 xorg_xextproto:
   - '7'
 xorg_xorgproto:
-  - '2024'
+  - '2025'
 xxhash:
   - 0.8.3
 xz:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/33116977923)

xorg_xorgproto updated to 2025

Explore required actions on depends of xorg_xorgproto by calling:
```
pbc migration identify distro-db xorg_xorgproto:2025
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
