### PR TITLE
raise the osx-arm64 macOS floor to 13.3

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -22,7 +22,7 @@ c_stdlib:
 c_stdlib_version:
   - 2.28                       # [linux]
   - 10.15                      # [osx and x86_64]
-  - 12.1                       # [osx and arm64]
+  - 13.3                       # [osx and arm64]
   - 2022.14                    # [win]
 cxx_compiler:
   - gxx                        # [linux]
@@ -191,18 +191,21 @@ OSX_SDK_DIR:                                  # [osx]
 
 # TODO: These are only necessary as we transition to using the stdlib('c') macro. They should be
 # removed once it is safe to do so.
+# On osx-arm64 the build SDK and the deployment target are intentionally decoupled:
+# we build against the 14.5 SDK (present on the workers, already used by qtbase,
+# qtdeclarative and qtsvg) while targeting 13.3.
 CONDA_BUILD_SYSROOT:
   - /opt/MacOSX10.15.sdk                                     # [osx and x86_64]
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk  # [osx and arm64]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX14.5.sdk  # [osx and arm64]
 macos_min_version:
   - 10.15 # [osx and x86_64]
-  - 12.1  # [osx and arm64]
+  - 13.3  # [osx and arm64]
 macos_machine:
   - x86_64-apple-darwin13.4.0  # [osx and x86_64]
   - arm64-apple-darwin20.0.0   # [osx and arm64]
 MACOSX_DEPLOYMENT_TARGET:
   - 10.15 # [osx and x86_64]
-  - 12.1  # [osx and arm64]
+  - 13.3  # [osx and arm64]
 
 ## GLOBAL pinnings
 alsa_lib:


### PR DESCRIPTION
aggregate - raise the osx-arm64 macOS floor to 13.3

**Destination channel:** defaults

### Links

- [PKG-13634](https://anaconda.atlassian.net/browse/PKG-13634)
- [macOS platform support policy](https://www.anaconda.com/docs/reference/policies-practices/platform-support#macos)
- Evidence graph (canary, closed unmerged): https://package-build.anaconda.com/v1/graph/359e8f5a-5257-48e6-bbfb-f99590062d34

### Explanation of changes:

- **osx-arm64 floor 12.1 → 13.3.** 
- Build SDK 12.1 → 14.5



[PKG-13634]: https://anaconda.atlassian.net/browse/PKG-13634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ