### PR TITLE
Update pin for cfitsio 4.7.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -284,7 +284,7 @@ capnproto:
 ceres_solver:
   - '2.2'
 cfitsio:
-  - 4.6.3
+  - 4.7.0
 charls:
   - '2.4'
 coin_or_cbc:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/33423483641)

cfitsio updated to 4.7.0

Explore required actions on depends of cfitsio by calling:
```
pbc migration identify distro-db cfitsio:4.7.0
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
