### PR TITLE
Update pin for libass 0.17.5

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -484,7 +484,7 @@ libarchive:
 libasprintf:
   - '0'
 libass:
-  - 0.17.4
+  - 0.17.5
 libassuan:
   - '3'
 libavif:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/33454708802)

libass updated to 0.17.5

Explore required actions on depends of libass by calling:
```
pbc migration identify distro-db libass:0.17.5
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
