### PR TITLE
Update pin for rdkit 2026.3.5

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -928,7 +928,7 @@ qtwebsockets:
 quantlib:
   - '1'
 rdkit:
-  - 2025.9.6
+  - 2026.3.5
 rdma_core:
   - '61.0'
 re2:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/33506391295)

rdkit updated to 2026.3.5

Explore required actions on depends of rdkit by calling:
```
pbc migration identify distro-db rdkit:2026.3.5
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
