### PR TITLE
Update pin for libnvimgcodec 0.9.0, libnvimgcodec0 0.9.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -671,6 +671,10 @@ libntlm:
   - '1'
 libnuma:
   - '2'
+libnvimgcodec:
+  - 0.9.0
+libnvimgcodec0:
+  - 0.9.0
 libogg:
   - '1.3'
 libopenblas:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/33821347867)

libnvimgcodec updated to 0.9.0

Explore required actions on depends of libnvimgcodec by calling:
```
pbc migration identify distro-db libnvimgcodec:0.9.0
pbc migration export to_image  feedstock_dependencies.yaml
```

libnvimgcodec0 updated to 0.9.0

Explore required actions on depends of libnvimgcodec0 by calling:
```
pbc migration identify distro-db libnvimgcodec0:0.9.0
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
