### PR TITLE
Update pin for aom 3.14

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -210,7 +210,7 @@ alsa_lib:
 ampl_mp:
   - '3.1'
 aom:
-  - '3.13'
+  - '3.14'
 armadillo:
   - '12'
 arpack:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/34349611567)

aom updated to 3.14

Explore required actions on depends of aom by calling:
```
pbc migration identify distro-db aom:3.14
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
