### PR TITLE
Update pin for eccodes 2.47

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -311,6 +311,8 @@ dlfcn_win32:
   - '1'
 dpcpp_cpp_rt:
   - '2023'
+eccodes:
+  - '2.47'
 eigen:
   - 3.3.7
 elfutils:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/34387336291)

eccodes updated to 2.47

Explore required actions on depends of eccodes by calling:
```
pbc migration identify distro-db eccodes:2.47
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
