### PR TITLE
Update pin for pcre2 10.48

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -856,7 +856,7 @@ pango:
 pcre:
   - '8'
 pcre2:
-  - '10.46'
+  - '10.48'
 pdal:
   - '2.5'
 perl_class_inspector:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/34387336291)

pcre2 updated to 10.48

Explore required actions on depends of pcre2 by calling:
```
pbc migration identify distro-db pcre2:10.48
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
