### PR TITLE
Update pin for util_linux 2.42

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -990,7 +990,7 @@ ucx:
 unixodbc:
   - '2.3'
 util_linux:
-  - '2.39'
+  - '2.42'
 vcomp14:
   - 14.44.35208
 vtk_base:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/34387336291)

util_linux updated to 2.42

Explore required actions on depends of util_linux by calling:
```
pbc migration identify distro-db util_linux:2.42
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
