### PR TITLE
Update pin for libtorch 2.14, pytorch 2.14

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -738,7 +738,7 @@ libtirpc:
 libtmglib:
   - '3'
 libtorch:
-  - '2.13'
+  - '2.14'
 libunistring:
   - '1'
 libunwind:
@@ -896,7 +896,7 @@ pyqtwebengine:
 python_igraph:
   - '1.0'
 pytorch:
-  - '2.13'
+  - '2.14'
 qhull:
   - '2020.2'
 qpdf:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/34512587194)

libtorch updated to 2.14

Explore required actions on depends of libtorch by calling:
```
pbc migration identify distro-db libtorch:2.14
pbc migration export to_image  feedstock_dependencies.yaml
```

pytorch updated to 2.14

Explore required actions on depends of pytorch by calling:
```
pbc migration identify distro-db pytorch:2.14
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
