### PR TITLE
Update pin for aws_c_common 0.14.5

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -232,7 +232,7 @@ aws_c_auth:
 aws_c_cal:
   - 0.9.14
 aws_c_common:
-  - 0.14.0
+  - 0.14.5
 aws_c_compression:
   - 0.3.2
 aws_c_event_stream:


### PR DESCRIPTION
Automated conda_build_config.yaml pinning updates from package run_exports via [anaconda/aggregate-duct-tape](https://github.com/anaconda/aggregate-duct-tape/actions/runs/34661290330)

aws_c_common updated to 0.14.5

Explore required actions on depends of aws_c_common by calling:
```
pbc migration identify distro-db aws_c_common:0.14.5
pbc migration export to_image  feedstock_dependencies.yaml
```

After merge a compatibility report will be available at https://anaconda.github.io/distro-compatibility-report
